### PR TITLE
Fix #93 Ability to access settings when header is removed

### DIFF
--- a/app/calendar-widget/src/main/AndroidManifest.xml
+++ b/app/calendar-widget/src/main/AndroidManifest.xml
@@ -17,6 +17,10 @@
             <intent-filter>
                 <action android:name="android.appwidget.action.APPWIDGET_CONFIGURE" />
             </intent-filter>
+            <intent-filter>
+                <action android:name="android.intent.action.MAIN" />
+                <category android:name="android.intent.category.LAUNCHER" />
+            </intent-filter>
         </activity>
 
         <receiver


### PR DESCRIPTION
Now Widget configuration activity is available from Launcher
