### PR TITLE
Add support for per-widget settings (#37)

### DIFF
--- a/app/calendar-widget/src/main/java/com/plusonelabs/calendar/EventWidgetService.java
+++ b/app/calendar-widget/src/main/java/com/plusonelabs/calendar/EventWidgetService.java
@@ -1,9 +1,14 @@
 package com.plusonelabs.calendar;
 
+import android.appwidget.AppWidgetManager;
 import android.content.Context;
 import android.content.Intent;
+import android.content.SharedPreferences;
+import android.os.Bundle;
 import android.view.ContextThemeWrapper;
 import android.widget.RemoteViewsService;
+
+import com.plusonelabs.calendar.prefs.UniquePreferencesFragment;
 
 import static com.plusonelabs.calendar.Theme.getCurrentThemeId;
 import static com.plusonelabs.calendar.prefs.CalendarPreferences.PREF_ENTRY_THEME;
@@ -15,8 +20,11 @@ public class EventWidgetService extends RemoteViewsService {
 	@Override
 	public RemoteViewsFactory onGetViewFactory(Intent intent) {
         Context appContext = getApplicationContext();
-        int currentThemeId = getCurrentThemeId(appContext, PREF_ENTRY_THEME, PREF_ENTRY_THEME_DEFAULT);
+        Bundle extras = intent.getExtras();
+        int widgetId = extras.getInt(AppWidgetManager.EXTRA_APPWIDGET_ID);
+        SharedPreferences prefs = UniquePreferencesFragment.getPreferences(appContext, widgetId);
+        int currentThemeId = getCurrentThemeId(appContext, PREF_ENTRY_THEME, PREF_ENTRY_THEME_DEFAULT, prefs);
         ContextThemeWrapper context = new ContextThemeWrapper(appContext, currentThemeId);
-        return new EventRemoteViewsFactory(context);
+        return new EventRemoteViewsFactory(context, prefs);
     }
 }

--- a/app/calendar-widget/src/main/java/com/plusonelabs/calendar/RemoteViewsUtil.java
+++ b/app/calendar-widget/src/main/java/com/plusonelabs/calendar/RemoteViewsUtil.java
@@ -27,12 +27,12 @@ public class RemoteViewsUtil {
 
 	@TargetApi(Build.VERSION_CODES.JELLY_BEAN)
 	public static void setPadding(Context context, RemoteViews rv, int viewId, int leftDimenId,
-			int topDimenId, int rightDimenId, int bottomDimenId) {
+			int topDimenId, int rightDimenId, int bottomDimenId, SharedPreferences prefs) {
 		if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.JELLY_BEAN) {
-			int leftPadding = Math.round(getScaledValueInPixel(context, leftDimenId));
-			int topPadding = Math.round(getScaledValueInPixel(context, topDimenId));
-			int rightPadding = Math.round(getScaledValueInPixel(context, rightDimenId));
-			int bottomPadding = Math.round(getScaledValueInPixel(context, bottomDimenId));
+			int leftPadding = Math.round(getScaledValueInPixel(context, leftDimenId, prefs));
+			int topPadding = Math.round(getScaledValueInPixel(context, topDimenId, prefs));
+			int rightPadding = Math.round(getScaledValueInPixel(context, rightDimenId, prefs));
+			int bottomPadding = Math.round(getScaledValueInPixel(context, bottomDimenId, prefs));
 			rv.setViewPadding(viewId, leftPadding, topPadding, rightPadding, bottomPadding);
 		}
 	}
@@ -45,8 +45,8 @@ public class RemoteViewsUtil {
 		rv.setInt(viewId, METHOD_SET_COLOR_FILTER, color);
 	}
 
-	public static void setTextSize(Context context, RemoteViews rv, int viewId, int dimenId) {
-		rv.setFloat(viewId, METHOD_SET_TEXT_SIZE, getScaledValue(context, dimenId));
+	public static void setTextSize(Context context, RemoteViews rv, int viewId, int dimenId, SharedPreferences prefs) {
+		rv.setFloat(viewId, METHOD_SET_TEXT_SIZE, getScaledValue(context, dimenId, prefs));
 	}
 
     public static void setTextColorFromAttr(Context context, RemoteViews rv, int viewId, int colorAttrId) {
@@ -63,17 +63,15 @@ public class RemoteViewsUtil {
 	}
 
 
-    private static float getScaledValueInPixel(Context context, int dimenId) {
+    private static float getScaledValueInPixel(Context context, int dimenId, SharedPreferences prefs) {
         float resValue = getDimension(context, dimenId);
-        SharedPreferences prefs = PreferenceManager.getDefaultSharedPreferences(context);
         float prefTextScale = parseFloat(prefs.getString(PREF_TEXT_SIZE_SCALE,
 				PREF_TEXT_SIZE_SCALE_DEFAULT));
 		return resValue * prefTextScale;
 	}
 
-	private static float getScaledValue(Context context, int dimenId) {
+	private static float getScaledValue(Context context, int dimenId, SharedPreferences prefs) {
         float resValue = getDimension(context, dimenId);
-        SharedPreferences prefs = PreferenceManager.getDefaultSharedPreferences(context);
         float density = context.getResources().getDisplayMetrics().density;
         float prefTextScale = parseFloat(prefs.getString(PREF_TEXT_SIZE_SCALE,
 				PREF_TEXT_SIZE_SCALE_DEFAULT));

--- a/app/calendar-widget/src/main/java/com/plusonelabs/calendar/Theme.java
+++ b/app/calendar-widget/src/main/java/com/plusonelabs/calendar/Theme.java
@@ -17,8 +17,7 @@ public enum Theme {
         this.themeResId = themeResId;
     }
 
-    public static int getCurrentThemeId(Context context, String prefKey, String prefDefault) {
-        SharedPreferences prefs = PreferenceManager.getDefaultSharedPreferences(context);
+    public static int getCurrentThemeId(Context context, String prefKey, String prefDefault, SharedPreferences prefs) {
         return Theme.valueOf(prefs.getString(prefKey, prefDefault)).themeResId;
     }
 

--- a/app/calendar-widget/src/main/java/com/plusonelabs/calendar/WidgetConfigurationActivity.java
+++ b/app/calendar-widget/src/main/java/com/plusonelabs/calendar/WidgetConfigurationActivity.java
@@ -6,6 +6,7 @@ import android.content.Intent;
 import android.os.Build;
 import android.os.Bundle;
 import android.preference.PreferenceActivity;
+import android.util.Log;
 import android.util.TypedValue;
 import android.view.View;
 import android.view.View.OnClickListener;
@@ -19,20 +20,41 @@ import static android.view.ViewGroup.LayoutParams.MATCH_PARENT;
 public class WidgetConfigurationActivity extends PreferenceActivity {
 
     private static final String PREFERENCES_PACKAGE_NAME = "com.plusonelabs.calendar.prefs";
+    public static final String WIDGET_INIT = "widgetInit";
 
-    private int appWidgetId = AppWidgetManager.INVALID_APPWIDGET_ID;
+    public int appWidgetId = AppWidgetManager.INVALID_APPWIDGET_ID;
+    private boolean init = true;
 
     @Override
     public void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
-        Bundle extras = getIntent().getExtras();
-        if (extras != null) {
-            appWidgetId = extras.getInt(AppWidgetManager.EXTRA_APPWIDGET_ID,
-                    AppWidgetManager.INVALID_APPWIDGET_ID);
+        if (savedInstanceState != null) {
+            appWidgetId = savedInstanceState.getInt(AppWidgetManager.EXTRA_APPWIDGET_ID);
+            init = savedInstanceState.getBoolean(WidgetConfigurationActivity.WIDGET_INIT);
+        } else {
+            Bundle extras = getIntent().getExtras();
+            if (extras != null) {
+                appWidgetId = extras.getInt(AppWidgetManager.EXTRA_APPWIDGET_ID,
+                        AppWidgetManager.INVALID_APPWIDGET_ID);
+                init = extras.getBoolean(WidgetConfigurationActivity.WIDGET_INIT, true);
+            }
         }
-        if (hasHeaders() && appWidgetId != AppWidgetManager.INVALID_APPWIDGET_ID) {
+        if (init && appWidgetId != AppWidgetManager.INVALID_APPWIDGET_ID && hasHeaders()) {
             createAddButton();
         }
+    }
+
+    @Override
+    public Intent onBuildStartFragmentIntent (String fragmentName, Bundle args, int titleRes, int shortTitleRes) {
+        Intent intent = super.onBuildStartFragmentIntent(fragmentName, args, titleRes, shortTitleRes);
+        intent.putExtra(AppWidgetManager.EXTRA_APPWIDGET_ID, this.appWidgetId);
+        return intent;
+    }
+
+    @Override
+    protected void onSaveInstanceState(Bundle outState) {
+        outState.putInt(AppWidgetManager.EXTRA_APPWIDGET_ID, appWidgetId);
+        outState.putBoolean(WidgetConfigurationActivity.WIDGET_INIT, init);
     }
 
     private void createAddButton() {

--- a/app/calendar-widget/src/main/java/com/plusonelabs/calendar/calendar/CalendarEventProvider.java
+++ b/app/calendar-widget/src/main/java/com/plusonelabs/calendar/calendar/CalendarEventProvider.java
@@ -49,9 +49,11 @@ public class CalendarEventProvider {
     private static final String AND_BRACKET = " AND (";
 
     private final Context context;
+    private final SharedPreferences prefs;
 
-    public CalendarEventProvider(Context context) {
+    public CalendarEventProvider(Context context, SharedPreferences prefs) {
         this.context = context;
+        this.prefs = prefs;
     }
 
     public List<CalendarEvent> getEvents() {
@@ -66,7 +68,6 @@ public class CalendarEventProvider {
     }
 
     private List<CalendarEvent> createEventList(Cursor calendarCursor) {
-        SharedPreferences prefs = PreferenceManager.getDefaultSharedPreferences(context);
         boolean fillAllDayEvents = prefs.getBoolean(PREF_FILL_ALL_DAY, PREF_FILL_ALL_DAY_DEFAULT);
         List<CalendarEvent> eventList = new ArrayList<>();
         for (int i = 0; i < calendarCursor.getCount(); i++) {
@@ -164,7 +165,6 @@ public class CalendarEventProvider {
     }
 
     private Cursor createLoadedCursor() {
-        SharedPreferences prefs = PreferenceManager.getDefaultSharedPreferences(context);
         int dateRange = Integer
                 .valueOf(prefs.getString(PREF_EVENT_RANGE, PREF_EVENT_RANGE_DEFAULT));
         long start = System.currentTimeMillis();
@@ -185,7 +185,6 @@ public class CalendarEventProvider {
     }
 
     private String createSelectionClause() {
-        SharedPreferences prefs = PreferenceManager.getDefaultSharedPreferences(context);
         Set<String> activeCalenders = prefs.getStringSet(CalendarPreferences.PREF_ACTIVE_CALENDARS,
                 new HashSet<String>());
         if (activeCalenders.isEmpty()) {

--- a/app/calendar-widget/src/main/java/com/plusonelabs/calendar/calendar/CalendarEventVisualizer.java
+++ b/app/calendar-widget/src/main/java/com/plusonelabs/calendar/calendar/CalendarEventVisualizer.java
@@ -13,6 +13,7 @@ import com.plusonelabs.calendar.DateUtil;
 import com.plusonelabs.calendar.IEventVisualizer;
 import com.plusonelabs.calendar.R;
 import com.plusonelabs.calendar.model.Event;
+import com.plusonelabs.calendar.prefs.UniquePreferencesFragment;
 
 import org.joda.time.DateTime;
 
@@ -55,10 +56,10 @@ public class CalendarEventVisualizer implements IEventVisualizer<CalendarEvent> 
 	private final CalendarEventProvider calendarContentProvider;
 	private final SharedPreferences prefs;
 
-	public CalendarEventVisualizer(Context context) {
+	public CalendarEventVisualizer(Context context, SharedPreferences prefs) {
 		this.context = context;
-		calendarContentProvider = new CalendarEventProvider(context);
-		prefs = PreferenceManager.getDefaultSharedPreferences(context);
+        this.prefs = prefs;
+		calendarContentProvider = new CalendarEventProvider(context, prefs);
 	}
 
 	public RemoteViews getRemoteView(Event eventEntry) {
@@ -79,7 +80,7 @@ public class CalendarEventVisualizer implements IEventVisualizer<CalendarEvent> 
 			title = context.getResources().getString(R.string.no_title);
 		}
 		rv.setTextViewText(R.id.event_entry_title, title);
-		setTextSize(context, rv, R.id.event_entry_title, R.dimen.event_entry_title);
+		setTextSize(context, rv, R.id.event_entry_title, R.dimen.event_entry_title, prefs);
         setTextColorFromAttr(context, rv, R.id.event_entry_title, R.attr.eventEntryTitle);
         setSingleLine(rv, R.id.event_entry_title,
                 !prefs.getBoolean(PREF_MULTILINE_TITLE, PREF_MULTILINE_TITLE_DEFAULT));
@@ -99,7 +100,7 @@ public class CalendarEventVisualizer implements IEventVisualizer<CalendarEvent> 
             }
             rv.setViewVisibility(R.id.event_entry_details, View.VISIBLE);
             rv.setTextViewText(R.id.event_entry_details, eventDetails);
-            setTextSize(context, rv, R.id.event_entry_details, R.dimen.event_entry_details);
+            setTextSize(context, rv, R.id.event_entry_details, R.dimen.event_entry_details, prefs);
             setTextColorFromAttr(context, rv, R.id.event_entry_details, R.attr.eventEntryDetails);
         }
     }
@@ -118,7 +119,7 @@ public class CalendarEventVisualizer implements IEventVisualizer<CalendarEvent> 
         if (showIndication) {
             rv.setViewVisibility(viewId, View.VISIBLE);
             setImageFromAttr(context, rv, viewId, imageAttrId);
-            int themeId = getCurrentThemeId(context, PREF_ENTRY_THEME, PREF_ENTRY_THEME_DEFAULT);
+            int themeId = getCurrentThemeId(context, PREF_ENTRY_THEME, PREF_ENTRY_THEME_DEFAULT, prefs);
             int alpha = 255;
             if (themeId == R.style.Theme_Calendar_Dark || themeId == R.style.Theme_Calendar_Light) {
                 alpha = 128;
@@ -178,7 +179,6 @@ public class CalendarEventVisualizer implements IEventVisualizer<CalendarEvent> 
     }
 
     private String createTimeString(DateTime time) {
-        SharedPreferences prefs = PreferenceManager.getDefaultSharedPreferences(context);
         String dateFormat = prefs.getString(PREF_DATE_FORMAT, PREF_DATE_FORMAT_DEFAULT);
         if (DateUtil.hasAmPmClock(Locale.getDefault()) && dateFormat.equals(AUTO)
                 || dateFormat.equals(TWELVE)) {

--- a/app/calendar-widget/src/main/java/com/plusonelabs/calendar/prefs/AppearancePreferencesFragment.java
+++ b/app/calendar-widget/src/main/java/com/plusonelabs/calendar/prefs/AppearancePreferencesFragment.java
@@ -1,16 +1,16 @@
 package com.plusonelabs.calendar.prefs;
 
+import android.appwidget.AppWidgetManager;
 import android.os.Bundle;
 import android.preference.CheckBoxPreference;
 import android.preference.Preference;
-import android.preference.PreferenceFragment;
 import android.preference.PreferenceScreen;
 import android.widget.Toast;
 
 import com.plusonelabs.calendar.EventAppWidgetProvider;
 import com.plusonelabs.calendar.R;
 
-public class AppearancePreferencesFragment extends PreferenceFragment {
+public class AppearancePreferencesFragment extends UniquePreferencesFragment {
 
 	private static final String BACKGROUND_COLOR_DIALOG = "backgroundColorDialog";
 
@@ -32,8 +32,11 @@ public class AppearancePreferencesFragment extends PreferenceFragment {
 			}
 		}
 		if (preference.getKey().equals(CalendarPreferences.PREF_BACKGROUND_COLOR)) {
-			new BackgroundTransparencyDialog().show(getFragmentManager(),
-                    BACKGROUND_COLOR_DIALOG);
+            BackgroundTransparencyDialog btd = new BackgroundTransparencyDialog();
+            Bundle args = new Bundle();
+            args.putInt(AppWidgetManager.EXTRA_APPWIDGET_ID, this.appWidgetId);
+            btd.setArguments(args);
+            btd.show(getFragmentManager(), BACKGROUND_COLOR_DIALOG);
 		}
 		return super.onPreferenceTreeClick(preferenceScreen, preference);
 	}

--- a/app/calendar-widget/src/main/java/com/plusonelabs/calendar/prefs/BackgroundTransparencyDialog.java
+++ b/app/calendar-widget/src/main/java/com/plusonelabs/calendar/prefs/BackgroundTransparencyDialog.java
@@ -3,12 +3,14 @@ package com.plusonelabs.calendar.prefs;
 import android.app.AlertDialog;
 import android.app.Dialog;
 import android.app.DialogFragment;
+import android.appwidget.AppWidgetManager;
 import android.content.DialogInterface;
 import android.content.DialogInterface.OnClickListener;
 import android.content.SharedPreferences;
 import android.content.SharedPreferences.Editor;
 import android.os.Bundle;
 import android.preference.PreferenceManager;
+import android.util.Log;
 import android.view.LayoutInflater;
 import android.view.View;
 
@@ -23,6 +25,14 @@ import static com.plusonelabs.calendar.prefs.CalendarPreferences.PREF_BACKGROUND
 public class BackgroundTransparencyDialog extends DialogFragment {
 
     private ColorPicker picker;
+    private int widgetId = AppWidgetManager.INVALID_APPWIDGET_ID;
+
+    @Override
+    public void setArguments(Bundle args) {
+        if (args != null) {
+            widgetId = args.getInt(AppWidgetManager.EXTRA_APPWIDGET_ID);
+        }
+    }
 
     @Override
     public Dialog onCreateDialog(Bundle savedInstanceState) {
@@ -31,27 +41,24 @@ public class BackgroundTransparencyDialog extends DialogFragment {
         picker = (ColorPicker) layout.findViewById(R.id.background_color_picker);
         picker.addSVBar((SVBar) layout.findViewById(R.id.background_color_svbar));
         picker.addOpacityBar((OpacityBar) layout.findViewById(R.id.background_color_opacitybar));
-        SharedPreferences prefs = PreferenceManager.getDefaultSharedPreferences(getActivity());
+        SharedPreferences prefs = UniquePreferencesFragment.getPreferences(getActivity().getApplicationContext(), widgetId);
         int color = prefs.getInt(PREF_BACKGROUND_COLOR, PREF_BACKGROUND_COLOR_DEFAULT);
         picker.setColor(color);
         picker.setOldCenterColor(color);
-        return createDialog(layout);
+        return createDialog(layout, prefs);
     }
 
-
-    private Dialog createDialog(View layout) {
+    private Dialog createDialog(View layout, final SharedPreferences prefs) {
         AlertDialog.Builder builder = new AlertDialog.Builder(getActivity());
         builder.setTitle(R.string.appearance_background_color_title);
         builder.setView(layout);
         builder.setPositiveButton(android.R.string.ok, new OnClickListener() {
 
 			public void onClick(DialogInterface dialog, int which) {
-				SharedPreferences prefs = PreferenceManager
-						.getDefaultSharedPreferences(getActivity());
 				Editor editor = prefs.edit();
                 editor.putInt(PREF_BACKGROUND_COLOR, picker.getColor());
                 editor.commit();
-            }
+                }
 		});
 		return builder.create();
 	}

--- a/app/calendar-widget/src/main/java/com/plusonelabs/calendar/prefs/CalendarPreferencesFragment.java
+++ b/app/calendar-widget/src/main/java/com/plusonelabs/calendar/prefs/CalendarPreferencesFragment.java
@@ -10,7 +10,6 @@ import android.net.Uri;
 import android.os.Bundle;
 import android.preference.CheckBoxPreference;
 import android.preference.Preference;
-import android.preference.PreferenceFragment;
 import android.preference.PreferenceScreen;
 import android.provider.CalendarContract.Calendars;
 
@@ -22,7 +21,7 @@ import java.util.Set;
 
 import static com.plusonelabs.calendar.prefs.CalendarPreferences.PREF_ACTIVE_CALENDARS;
 
-public class CalendarPreferencesFragment extends PreferenceFragment {
+public class CalendarPreferencesFragment extends UniquePreferencesFragment {
 
 	private static final String CALENDAR_ID = "calendarId";
 	private static final String[] PROJECTION = new String[] { Calendars._ID,
@@ -35,8 +34,7 @@ public class CalendarPreferencesFragment extends PreferenceFragment {
 		super.onCreate(savedInstanceState);
 		addPreferencesFromResource(R.xml.preferences_calendars);
 		SharedPreferences prefs = getPreferenceManager().getSharedPreferences();
-		initialActiveCalendars = prefs.getStringSet(PREF_ACTIVE_CALENDARS,
-				null);
+		initialActiveCalendars = prefs.getStringSet(PREF_ACTIVE_CALENDARS, null);
 		populatePreferenceScreen(initialActiveCalendars);
 	}
 

--- a/app/calendar-widget/src/main/java/com/plusonelabs/calendar/prefs/EventDetailsPreferencesFragment.java
+++ b/app/calendar-widget/src/main/java/com/plusonelabs/calendar/prefs/EventDetailsPreferencesFragment.java
@@ -1,12 +1,11 @@
 package com.plusonelabs.calendar.prefs;
 
 import android.os.Bundle;
-import android.preference.PreferenceFragment;
 
 import com.plusonelabs.calendar.EventAppWidgetProvider;
 import com.plusonelabs.calendar.R;
 
-public class EventDetailsPreferencesFragment extends PreferenceFragment {
+public class EventDetailsPreferencesFragment extends UniquePreferencesFragment {
 
 	@Override
 	public void onCreate(Bundle savedInstanceState) {

--- a/app/calendar-widget/src/main/java/com/plusonelabs/calendar/prefs/FeedbackPreferencesFragment.java
+++ b/app/calendar-widget/src/main/java/com/plusonelabs/calendar/prefs/FeedbackPreferencesFragment.java
@@ -1,11 +1,10 @@
 package com.plusonelabs.calendar.prefs;
 
 import android.os.Bundle;
-import android.preference.PreferenceFragment;
 
 import com.plusonelabs.calendar.R;
 
-public class FeedbackPreferencesFragment extends PreferenceFragment {
+public class FeedbackPreferencesFragment extends UniquePreferencesFragment {
 
 	@Override
 	public void onCreate(Bundle savedInstanceState) {

--- a/app/calendar-widget/src/main/java/com/plusonelabs/calendar/prefs/UniquePreferencesFragment.java
+++ b/app/calendar-widget/src/main/java/com/plusonelabs/calendar/prefs/UniquePreferencesFragment.java
@@ -1,0 +1,37 @@
+package com.plusonelabs.calendar.prefs;
+
+import android.appwidget.AppWidgetManager;
+import android.content.Context;
+import android.content.SharedPreferences;
+import android.os.Bundle;
+import android.preference.PreferenceFragment;
+import android.preference.PreferenceManager;
+import android.util.Log;
+
+public abstract class UniquePreferencesFragment extends PreferenceFragment {
+
+    protected int appWidgetId = AppWidgetManager.INVALID_APPWIDGET_ID;
+    private static final String PACKAGE_NAME = "com.plusonelabs.calendar.prefs";
+
+    @Override
+    public void onCreate(Bundle savedInstanceState) {
+        if (savedInstanceState != null) {
+            appWidgetId = savedInstanceState.getInt(AppWidgetManager.EXTRA_APPWIDGET_ID);
+        } else {
+            Bundle extras = getActivity().getIntent().getExtras();
+            if (extras != null) {
+                appWidgetId = extras.getInt(AppWidgetManager.EXTRA_APPWIDGET_ID,
+                        AppWidgetManager.INVALID_APPWIDGET_ID);
+            }
+        }
+
+        super.onCreate(savedInstanceState);
+
+        PreferenceManager manager = this.getPreferenceManager();
+        manager.setSharedPreferencesName(PACKAGE_NAME + appWidgetId);
+    }
+
+    public static SharedPreferences getPreferences(Context context, int widgetId) {
+        return context.getSharedPreferences(PACKAGE_NAME + widgetId, Context.MODE_PRIVATE);
+    }
+}


### PR DESCRIPTION
This commit separates the settings for each instance of the widget, so that different widget instances can display different calendars.
