### PR TITLE
Don't show end time if same as start time

### DIFF
--- a/app/calendar-widget/src/main/java/com/plusonelabs/calendar/calendar/CalendarEventVisualizer.java
+++ b/app/calendar-widget/src/main/java/com/plusonelabs/calendar/calendar/CalendarEventVisualizer.java
@@ -174,6 +174,11 @@ public class CalendarEventVisualizer implements IEventVisualizer<CalendarEvent> 
             separator = EMPTY_STRING;
             endStr = EMPTY_STRING;
         }
+
+        if (startStr.equals(endStr)) {
+            return startStr;
+        }
+        
         return startStr + separator + endStr;
     }
 


### PR DESCRIPTION
So instead of "9:00-9:00" we now display only "9:00", but for
"9:00-9:45" we still display "9:00-9:45" just as before.