### PR TITLE
calendar-widget-165 Calendar widget does not appear in list of widgets

### DIFF
--- a/app/calendar-widget/src/main/AndroidManifest.xml
+++ b/app/calendar-widget/src/main/AndroidManifest.xml
@@ -1,7 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
           xmlns:tools="http://schemas.android.com/tools"
-          package="com.plusonelabs.calendar">
+          package="com.plusonelabs.calendar"
+          android:installLocation="internalOnly">
 
     <uses-permission android:name="android.permission.READ_CALENDAR" />
 


### PR DESCRIPTION
This change allows to avoid at least one cause of the problem: installation into external memory.