### PR TITLE
Preferences restructured. New "Event filters" header introduced

### DIFF
--- a/app/calendar-widget/src/main/java/com/plusonelabs/calendar/calendar/CalendarEvent.java
+++ b/app/calendar-widget/src/main/java/com/plusonelabs/calendar/calendar/CalendarEvent.java
@@ -91,7 +91,7 @@ public class CalendarEvent extends Event {
 	}
 
 	public int daysSpanned() {
-		DateTime startMidnight = getStartDate().withTimeAtStartOfDay();
+		DateTime startMidnight = getStartDay();
 		DateTime endMidnight = getEndDate().withTimeAtStartOfDay();
 		int days = Days.daysBetween(startMidnight, endMidnight).getDays();
 		if (!isAllDay() && !getEndDate().equals(endMidnight)) {
@@ -121,7 +121,7 @@ public class CalendarEvent extends Event {
 	}
 
 	public int compareTo(CalendarEvent otherEntry) {
-		if (isSameDay(otherEntry.getStartDate())) {
+		if (startsSameDay(otherEntry.getStartDate())) {
 			if (allDay) {
 				return -1;
 			} else if (otherEntry.allDay) {

--- a/app/calendar-widget/src/main/java/com/plusonelabs/calendar/calendar/CalendarEventProvider.java
+++ b/app/calendar-widget/src/main/java/com/plusonelabs/calendar/calendar/CalendarEventProvider.java
@@ -169,7 +169,7 @@ public class CalendarEventProvider {
         if (isEqualOrAfterTodayAtMidnight(event.getStartDate())) {
             if (event.daysSpanned() > 1) {
                 CalendarEvent clone = event.clone();
-                clone.setEndDate(event.getStartDate().plusDays(1).withTimeAtStartOfDay());
+                clone.setEndDate(event.getStartDay().plusDays(1));
                 clone.setSpansMultipleDays(true);
                 clone.setOriginalEvent(event);
                 eventList.add(clone);
@@ -182,7 +182,7 @@ public class CalendarEventProvider {
     public void createFollowingEntries(List<CalendarEvent> eventList, CalendarEvent event) {
         int daysCovered = event.daysSpanned();
         for (int j = 1; j < daysCovered; j++) {
-            DateTime startDate = event.getStartDate().withTimeAtStartOfDay().plusDays(j);
+            DateTime startDate = event.getStartDay().plusDays(j);
             if (isEqualOrAfterTodayAtMidnight(startDate)) {
                 DateTime endDate;
                 if (j < daysCovered - 1) {

--- a/app/calendar-widget/src/main/java/com/plusonelabs/calendar/model/DayHeader.java
+++ b/app/calendar-widget/src/main/java/com/plusonelabs/calendar/model/DayHeader.java
@@ -5,7 +5,7 @@ import org.joda.time.DateTime;
 public class DayHeader extends Event {
 
 	public DayHeader(DateTime date) {
-		setStartDate(date);
+		setStartDate(date.withTimeAtStartOfDay());
 	}
 
 	@Override

--- a/app/calendar-widget/src/main/java/com/plusonelabs/calendar/model/Event.java
+++ b/app/calendar-widget/src/main/java/com/plusonelabs/calendar/model/Event.java
@@ -14,16 +14,20 @@ public class Event implements Comparable<Event> {
 		this.startDate = startDate;
 	}
 
-	public boolean isSameDay(DateTime otherDate) {
-		return startDate.withTimeAtStartOfDay().isEqual(otherDate.withTimeAtStartOfDay());
+    public DateTime getStartDay() {
+        return getStartDate().withTimeAtStartOfDay();
+    }
+
+	public boolean startsSameDay(DateTime otherDate) {
+		return getStartDay().isEqual(otherDate.withTimeAtStartOfDay());
 	}
 
-	public boolean isToday() {
-		return isSameDay(new DateTime());
+	public boolean startsToday() {
+		return startsSameDay(new DateTime());
 	}
 
-	public boolean isTomorrow() {
-		return isSameDay(new DateTime().plusDays(1));
+	public boolean startsTomorrow() {
+		return startsSameDay(new DateTime().plusDays(1));
 	}
 
 	@Override

--- a/app/calendar-widget/src/main/java/com/plusonelabs/calendar/prefs/CalendarPreferences.java
+++ b/app/calendar-widget/src/main/java/com/plusonelabs/calendar/prefs/CalendarPreferences.java
@@ -10,6 +10,7 @@ public class CalendarPreferences {
 	public static final String PREF_MULTILINE_TITLE = "multiline_title";
 	public static final boolean PREF_MULTILINE_TITLE_DEFAULT = false;
 	public static final String PREF_ACTIVE_CALENDARS = "activeCalendars";
+	public static final String PREF_SHOW_DAYS_WITHOUT_EVENTS = "showDaysWithoutEvents";
 	public static final String PREF_SHOW_HEADER = "showHeader";
 	public static final String PREF_INDICATE_RECURRING = "indicateRecurring";
 	public static final String PREF_INDICATE_ALERTS = "indicateAlerts";

--- a/app/calendar-widget/src/main/java/com/plusonelabs/calendar/prefs/EventFiltersPreferencesFragment.java
+++ b/app/calendar-widget/src/main/java/com/plusonelabs/calendar/prefs/EventFiltersPreferencesFragment.java
@@ -1,0 +1,23 @@
+package com.plusonelabs.calendar.prefs;
+
+import android.os.Bundle;
+import android.preference.PreferenceFragment;
+
+import com.plusonelabs.calendar.EventAppWidgetProvider;
+import com.plusonelabs.calendar.R;
+
+public class EventFiltersPreferencesFragment extends PreferenceFragment {
+
+	@Override
+	public void onCreate(Bundle savedInstanceState) {
+		super.onCreate(savedInstanceState);
+		addPreferencesFromResource(R.xml.preferences_event_filters);
+	}
+
+	@Override
+	public void onPause() {
+		super.onPause();
+		EventAppWidgetProvider.updateEventList(getActivity());
+		EventAppWidgetProvider.updateAllWidgets(getActivity());
+	}
+}

--- a/app/calendar-widget/src/main/res/values/arrays.xml
+++ b/app/calendar-widget/src/main/res/values/arrays.xml
@@ -67,12 +67,12 @@
         <item>180</item>
         <item>365</item>
     </string-array>
-    <string-array name="pref_show_past_events_with_color_entries">
-        <item>@string/show_past_events_with_color_none</item>
-        <item>@string/show_past_events_with_color_same</item>
-        <item>@string/show_past_events_with_color_other</item>
+    <string-array name="pref_show_events_with_color_entries">
+        <item>@string/show_events_with_color_none</item>
+        <item>@string/show_events_with_color_same</item>
+        <item>@string/show_events_with_color_other</item>
     </string-array>
-    <string-array name="pref_show_past_events_with_color_values" tools:ignore="MissingTranslation">
+    <string-array name="pref_show_events_with_color_values" tools:ignore="MissingTranslation">
         <item>NONE</item>
         <item>SAME</item>
         <item>OTHER</item>

--- a/app/calendar-widget/src/main/res/values/strings.xml
+++ b/app/calendar-widget/src/main/res/values/strings.xml
@@ -33,6 +33,8 @@
     <string name="appearance_date_format_auto">Automatic</string>
     <string name="appearance_date_format_24">17:00</string>
     <string name="appearance_date_format_12">5:00 pm</string>
+    <string name="appearance_show_days_without_events_title">Show days without events</string>
+    <string name="appearance_show_days_without_events_desc">Show day headers for days without events</string>
     <string name="appearance_display_header_title">Show widget header</string>
     <string name="appearance_display_header_desc">Show the date and settings header</string>
     <string name="appearance_display_header_warning">Hiding the header also stops you from getting back into the preferences.</string>

--- a/app/calendar-widget/src/main/res/values/strings.xml
+++ b/app/calendar-widget/src/main/res/values/strings.xml
@@ -12,11 +12,11 @@
     <string name="indicator_recurring">Indicator if the event is recurring</string>
     <string name="no_title">(No title)</string>
 
-    <!-- Preference calendars -->
+    <!-- Preference header: Calendars -->
     <string name="calendars_prefs">Calendars</string>
     <string name="calendars_prefs_desc">Select the calendars to display</string>
 
-    <!-- Preference appearance -->
+    <!-- Preference header: Appearance -->
     <string name="appearance_prefs">Appearance</string>
     <string name="appearance_prefs_desc">Adjust the appearance of the widget</string>
     <string name="appearance_text_size_title">Text size</string>
@@ -55,19 +55,9 @@
     <string name="appearance_theme_light">Dark</string>
     <string name="appearance_theme_white">Black</string>
 
-    <!-- Preferences event details -->
-    <string name="event_details_prefs">Events</string>
+    <!-- Preference header: Event details -->
+    <string name="event_details_prefs">Event details</string>
     <string name="event_details_prefs_desc">Configure what details to show for an event</string>
-    <string name="event_details_event_range_title">Date range</string>
-    <string name="event_details_event_range_desc">Configure the number of events to display</string>
-    <string name="event_range_one_day">One day</string>
-    <string name="event_range_one_week">One week</string>
-    <string name="event_range_two_weeks">Two weeks</string>
-    <string name="event_range_one_month">One month</string>
-    <string name="event_range_two_months">Two months</string>
-    <string name="event_range_three_months">Three months</string>
-    <string name="event_range_six_months">Six months</string>
-    <string name="event_range_one_year">One year</string>
     <string name="event_details_show_end_time_title">End time</string>
     <string name="event_details_show_end_time_desc">Show the event ending time</string>
     <string name="event_details_show_location_title">Show location</string>
@@ -79,13 +69,29 @@
     <string name="event_details_indicate_alert_title">Alerts</string>
     <string name="event_details_indicate_recurring_desc">Show indicator for recurring events</string>
     <string name="event_details_indicate_recurring_title">Recurring events</string>
+
+    <!-- Preference header: Event filters -->
+    <string name="event_filters_prefs">Event filters</string>
+    <string name="event_filters_prefs_desc">Which current, future and past events to show</string>
+    <string name="current_and_future_events">Current and future events</string>
+    <string name="past_events">Past events</string>
+    <string name="event_details_event_range_title">Date range</string>
+    <string name="event_details_event_range_desc">Configure the number of events to display</string>
+    <string name="event_range_one_day">One day</string>
+    <string name="event_range_one_week">One week</string>
+    <string name="event_range_two_weeks">Two weeks</string>
+    <string name="event_range_one_month">One month</string>
+    <string name="event_range_two_months">Two months</string>
+    <string name="event_range_three_months">Three months</string>
+    <string name="event_range_six_months">Six months</string>
+    <string name="event_range_one_year">One year</string>
     <string name="show_past_events_with_color_title">Show past events with color</string>
     <string name="show_past_events_with_color_desc">Allows you to see past events, which require your attention</string>
-    <string name="show_past_events_with_color_none">(this option is turned off)</string>
-    <string name="show_past_events_with_color_same">The same as default calendar color</string>
-    <string name="show_past_events_with_color_other">Other than default calendar color</string>
-        
-    <!-- Preference feedback -->
+    <string name="show_events_with_color_none">(this option is turned off)</string>
+    <string name="show_events_with_color_same">The same as default calendar color</string>
+    <string name="show_events_with_color_other">Other than default calendar color</string>
+
+    <!-- Preference header: Feedback -->
     <string name="feedback_prefs">Feedback</string>
     <string name="feedback_prefs_desc">Get in touch with us</string>
     <string name="feedback_github_desc">Provide feedback on the project page</string>

--- a/app/calendar-widget/src/main/res/xml/preferences_appearance.xml
+++ b/app/calendar-widget/src/main/res/xml/preferences_appearance.xml
@@ -32,6 +32,13 @@
         android:title="@string/appearance_day_header_alignment_title" />
 
     <CheckBoxPreference
+        android:defaultValue="false"
+        android:key="showDaysWithoutEvents"
+        android:summary="@string/appearance_show_days_without_events_desc"
+        android:title="@string/appearance_show_days_without_events_title">
+    </CheckBoxPreference>
+
+    <CheckBoxPreference
         android:defaultValue="true"
         android:key="showHeader"
         android:summary="@string/appearance_display_header_desc"

--- a/app/calendar-widget/src/main/res/xml/preferences_event_details.xml
+++ b/app/calendar-widget/src/main/res/xml/preferences_event_details.xml
@@ -1,21 +1,5 @@
 <PreferenceScreen xmlns:android="http://schemas.android.com/apk/res/android">
 
-    <ListPreference
-        android:defaultValue="30"
-        android:entries="@array/pref_event_range_entries"
-        android:entryValues="@array/pref_event_range_values"
-        android:key="eventRange"
-        android:summary="@string/event_details_event_range_desc"
-        android:title="@string/event_details_event_range_title" />
-
-    <ListPreference
-        android:defaultValue="none"
-        android:entries="@array/pref_show_past_events_with_color_entries"
-        android:entryValues="@array/pref_show_past_events_with_color_values"
-        android:key="showPastEventsWithColor"
-        android:summary="@string/show_past_events_with_color_desc"
-        android:title="@string/show_past_events_with_color_title" />
-
     <CheckBoxPreference
         android:key="showEndTime"
         android:title="@string/event_details_show_end_time_title"

--- a/app/calendar-widget/src/main/res/xml/preferences_event_filters.xml
+++ b/app/calendar-widget/src/main/res/xml/preferences_event_filters.xml
@@ -1,0 +1,20 @@
+<PreferenceScreen xmlns:android="http://schemas.android.com/apk/res/android">
+    <PreferenceCategory android:title="@string/past_events">
+        <ListPreference
+            android:defaultValue="none"
+            android:entries="@array/pref_show_events_with_color_entries"
+            android:entryValues="@array/pref_show_events_with_color_values"
+            android:key="showPastEventsWithColor"
+            android:summary="@string/show_past_events_with_color_desc"
+            android:title="@string/show_past_events_with_color_title" />
+    </PreferenceCategory>
+    <PreferenceCategory android:title="@string/current_and_future_events">
+        <ListPreference
+            android:defaultValue="30"
+            android:entries="@array/pref_event_range_entries"
+            android:entryValues="@array/pref_event_range_values"
+            android:key="eventRange"
+            android:summary="@string/event_details_event_range_desc"
+            android:title="@string/event_details_event_range_title" />
+    </PreferenceCategory>
+</PreferenceScreen>

--- a/app/calendar-widget/src/main/res/xml/preferences_header.xml
+++ b/app/calendar-widget/src/main/res/xml/preferences_header.xml
@@ -9,6 +9,10 @@
         android:summary="@string/event_details_prefs_desc"
         android:title="@string/event_details_prefs" />
     <header
+        android:fragment="com.plusonelabs.calendar.prefs.EventFiltersPreferencesFragment"
+        android:summary="@string/event_filters_prefs_desc"
+        android:title="@string/event_filters_prefs" />
+    <header
         android:fragment="com.plusonelabs.calendar.prefs.CalendarPreferencesFragment"
         android:summary="@string/calendars_prefs_desc"
         android:title="@string/calendars_prefs" />


### PR DESCRIPTION
New "Event filters" header introduced to allow further filtering enhancements.
Old "Events" header renamed to "Event details" - this is exactly what it is after removing "filters" from it!

Now it's much clearer to see, where we will put other proposed options like:
#151 Add ability to hide calendar events
#122 Show events that ended in past X hours (configurable)
and similar...