### PR TITLE
Fix NPE when not filling all-day events

### DIFF
--- a/app/calendar-widget/build.gradle
+++ b/app/calendar-widget/build.gradle
@@ -16,6 +16,11 @@ repositories {
 dependencies {
     compile 'joda-time:joda-time:2.7'
     compile 'com.larswerkman:HoloColorPicker:1.5'
+
+    testCompile 'junit:junit:4.12'
+    testCompile "org.mockito:mockito-core:1.10.19"
+    testCompile 'org.powermock:powermock-api-mockito:1.6.2'
+    testCompile 'org.powermock:powermock-module-junit4:1.6.2'
 }
 
 android {

--- a/app/calendar-widget/src/main/java/com/plusonelabs/calendar/calendar/CalendarEventProvider.java
+++ b/app/calendar-widget/src/main/java/com/plusonelabs/calendar/calendar/CalendarEventProvider.java
@@ -177,7 +177,8 @@ public class CalendarEventProvider {
         return stringBuilder.toString();
     }
 
-    private List<CalendarEvent> expandEventList(List<CalendarEvent> eventList) {
+    // This method has default protection for testability
+    List<CalendarEvent> expandEventList(List<CalendarEvent> eventList) {
         List<CalendarEvent> expandedList = new ArrayList<>();
         for (CalendarEvent event : eventList) {
             setupDayOneEntry(expandedList, event);

--- a/app/calendar-widget/src/main/java/com/plusonelabs/calendar/calendar/CalendarEventProvider.java
+++ b/app/calendar-widget/src/main/java/com/plusonelabs/calendar/calendar/CalendarEventProvider.java
@@ -190,15 +190,15 @@ public class CalendarEventProvider {
     }
 
     private void setupDayOneEntry(List<CalendarEvent> eventList, CalendarEvent event) {
+        CalendarEvent clone = event.clone();
+        clone.setOriginalEvent(event);
+
         if (event.daysSpanned() > 1) {
-            CalendarEvent clone = event.clone();
             clone.setEndDate(event.getStartDay().plusDays(1));
             clone.setSpansMultipleDays(true);
-            clone.setOriginalEvent(event);
-            eventList.add(clone);
-        } else {
-            eventList.add(event);
         }
+
+        eventList.add(clone);
     }
 
     private void createFollowingEntries(List<CalendarEvent> eventList, CalendarEvent event) {

--- a/app/calendar-widget/src/main/java/com/plusonelabs/calendar/calendar/CalendarEventVisualizer.java
+++ b/app/calendar-widget/src/main/java/com/plusonelabs/calendar/calendar/CalendarEventVisualizer.java
@@ -148,9 +148,10 @@ public class CalendarEventVisualizer implements IEventVisualizer<CalendarEvent> 
 				event.getStartDate(), event.getEndDate());
 	}
 
-	private String createTimeSpanString(CalendarEvent event) {
+	// This method has default protection for testability
+	String createTimeSpanString(CalendarEvent event) {
         if (event.isAllDay() && !prefs.getBoolean(PREF_FILL_ALL_DAY, PREF_FILL_ALL_DAY_DEFAULT)) {
-            DateTime dateTime = event.getOriginalEvent().getEndDate().minusDays(1);
+            DateTime dateTime = event.getEndDate().minusDays(1);
             return ARROW_SPACE + EMPTY_STRING + DateUtil.createDateString(context, dateTime);
         } else {
             return createTimeStringForEventEntry(event);

--- a/app/calendar-widget/src/main/java/com/plusonelabs/calendar/calendar/CalendarEventVisualizer.java
+++ b/app/calendar-widget/src/main/java/com/plusonelabs/calendar/calendar/CalendarEventVisualizer.java
@@ -151,7 +151,7 @@ public class CalendarEventVisualizer implements IEventVisualizer<CalendarEvent> 
 	// This method has default protection for testability
 	String createTimeSpanString(CalendarEvent event) {
         if (event.isAllDay() && !prefs.getBoolean(PREF_FILL_ALL_DAY, PREF_FILL_ALL_DAY_DEFAULT)) {
-            DateTime dateTime = event.getEndDate().minusDays(1);
+            DateTime dateTime = event.getOriginalEvent().getEndDate().minusDays(1);
             return ARROW_SPACE + EMPTY_STRING + DateUtil.createDateString(context, dateTime);
         } else {
             return createTimeStringForEventEntry(event);

--- a/app/calendar-widget/src/test/java/com/plusonelabs/calendar/calendar/CalendarEventProviderTest.java
+++ b/app/calendar-widget/src/test/java/com/plusonelabs/calendar/calendar/CalendarEventProviderTest.java
@@ -1,0 +1,41 @@
+package com.plusonelabs.calendar.calendar;
+
+import org.joda.time.DateTime;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.util.LinkedList;
+import java.util.List;
+
+public class CalendarEventProviderTest {
+    private final DateTime T_START;
+    private final DateTime T_START_PLUS_1;
+
+    public CalendarEventProviderTest() {
+        DateTime someDaysFromNow = new DateTime();
+        T_START = someDaysFromNow.withTimeAtStartOfDay().plusDays(6);
+        T_START_PLUS_1 = T_START.plusDays(1);
+    }
+
+    /**
+     * Verify that all events have non-null original events as per
+     * https://github.com/plusonelabs/calendar-widget/pull/180#issuecomment-132340031
+     */
+    @Test
+    public void testExpandEventList() {
+        CalendarEvent testEvent = new CalendarEvent();
+        testEvent.setStartDate(T_START);
+        testEvent.setEndDate(T_START_PLUS_1);
+
+        List<CalendarEvent> input = new LinkedList<>();
+        input.add(testEvent);
+
+        CalendarEventProvider testMe = new CalendarEventProvider(null);
+        List<CalendarEvent> result = testMe.expandEventList(input);
+        Assert.assertTrue("Result must be non-empty: " + result.size(),
+                result.size() > 0);
+        for (CalendarEvent event : result) {
+            Assert.assertNotNull(event.toString(), event.getOriginalEvent());
+        }
+    }
+}

--- a/app/calendar-widget/src/test/java/com/plusonelabs/calendar/calendar/CalendarEventVisualizerTest.java
+++ b/app/calendar-widget/src/test/java/com/plusonelabs/calendar/calendar/CalendarEventVisualizerTest.java
@@ -105,16 +105,6 @@ public class CalendarEventVisualizerTest {
     }
 
     @Test
-    public void testCreateTimeSpanStringNoFill() throws Exception {
-        CalendarEvent multiDayAllDay = new CalendarEvent();
-        multiDayAllDay.setAllDay(true);
-        multiDayAllDay.setStartDate(T_2015_JUL_9);
-        multiDayAllDay.setEndDate(T_2015_JUL_15);
-
-        Assert.assertEquals("→ Tue, Jul 14", createTimeSpanString(multiDayAllDay, false));
-    }
-
-    @Test
     public void testCreateTimeSpanStringFill() throws Exception {
         CalendarEvent multiDayAllDay = new CalendarEvent();
         multiDayAllDay.setAllDay(true);

--- a/app/calendar-widget/src/test/java/com/plusonelabs/calendar/calendar/CalendarEventVisualizerTest.java
+++ b/app/calendar-widget/src/test/java/com/plusonelabs/calendar/calendar/CalendarEventVisualizerTest.java
@@ -1,0 +1,126 @@
+package com.plusonelabs.calendar.calendar;
+
+import android.content.Context;
+import android.content.SharedPreferences;
+import android.preference.PreferenceManager;
+import android.text.format.DateUtils;
+import android.util.Log;
+
+import org.joda.time.DateTime;
+import org.joda.time.format.DateTimeFormat;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mockito;
+import org.mockito.invocation.InvocationOnMock;
+import org.mockito.stubbing.Answer;
+import org.powermock.api.mockito.PowerMockito;
+import org.powermock.core.classloader.annotations.PrepareForTest;
+import org.powermock.modules.junit4.PowerMockRunner;
+
+import java.util.Locale;
+
+import static com.plusonelabs.calendar.prefs.CalendarPreferences.PREF_DATE_FORMAT;
+import static com.plusonelabs.calendar.prefs.CalendarPreferences.PREF_DATE_FORMAT_DEFAULT;
+import static com.plusonelabs.calendar.prefs.CalendarPreferences.PREF_FILL_ALL_DAY;
+import static com.plusonelabs.calendar.prefs.CalendarPreferences.PREF_FILL_ALL_DAY_DEFAULT;
+
+/**
+ * Tests for {@link CalendarEventVisualizer}.
+ *
+ * @see <a href="http://tools.android.com/tech-docs/unit-testing-support">Android Tools Project Unit
+ * Testing Support</a>
+ */
+@RunWith(PowerMockRunner.class)
+@PrepareForTest({PreferenceManager.class, Log.class, DateUtils.class})
+public class CalendarEventVisualizerTest {
+    private static final DateTime T_2015_JUL_9 = new DateTime(2015, 7, 9, 0, 0);
+    private static final DateTime T_2015_JUL_15 = new DateTime(2015, 7, 15, 0, 0);
+
+    @Before
+    public void setUp() {
+        PowerMockito.mockStatic(Log.class);
+    }
+
+    /**
+     * Mock of {@link DateUtils#formatDateTime(Context, long, int)}.
+     */
+    private String formatDateTime(long msSinceEpoch, int flags) {
+        if (flags == (DateUtils.FORMAT_SHOW_TIME | DateUtils.FORMAT_24HOUR)) {
+            return DateTimeFormat.
+                    forPattern("HH:mm").
+                    withLocale(Locale.ENGLISH).
+                    print(msSinceEpoch);
+        }
+
+        if (flags == (DateUtils.FORMAT_SHOW_DATE | DateUtils.FORMAT_SHOW_WEEKDAY)) {
+            return DateTimeFormat.
+                    forPattern("EEE, MMM d").
+                    withLocale(Locale.ENGLISH).
+                    print(msSinceEpoch);
+        }
+
+        throw new IllegalArgumentException("Flags not supported by mock: " + flags);
+    }
+
+    private void mockPreferences(Context context, boolean fillAllDayEvents) {
+        SharedPreferences prefs;
+        PowerMockito.mockStatic(PreferenceManager.class);
+
+        prefs = Mockito.mock(SharedPreferences.class);
+        Mockito.when(prefs.getBoolean(PREF_FILL_ALL_DAY, PREF_FILL_ALL_DAY_DEFAULT)).
+                thenReturn(fillAllDayEvents);
+        Mockito.when(prefs.getString(PREF_DATE_FORMAT, PREF_DATE_FORMAT_DEFAULT)).
+                thenReturn("24");
+
+        Mockito.when(PreferenceManager.getDefaultSharedPreferences(context)).thenReturn(prefs);
+    }
+
+    private void mockDateUtils() {
+        PowerMockito.mockStatic(DateUtils.class);
+        Mockito.when(DateUtils.formatDateTime(Mockito.any(Context.class), Mockito.anyLong(), Mockito.anyInt())).
+                thenAnswer(new Answer<String>() {
+                    @Override
+                    public String answer(InvocationOnMock invocation) {
+                        int flags = (int) invocation.getArguments()[2];
+                        long msSinceEpoch = (long) invocation.getArguments()[1];
+                        return formatDateTime(msSinceEpoch, flags);
+                    }
+                });
+    }
+
+    /**
+     * Wrapper around {@link CalendarEventVisualizer#createTimeSpanString(CalendarEvent)} that sets
+     * up preferences, a context and DateUtils properly before calling the actual method we want to
+     * test.
+     */
+    private String createTimeSpanString(CalendarEvent event, boolean fillAllDayEvents) {
+        Context context = Mockito.mock(Context.class);
+        mockPreferences(context, fillAllDayEvents);
+        mockDateUtils();
+
+        CalendarEventVisualizer testMe = new CalendarEventVisualizer(context);
+        return testMe.createTimeSpanString(event);
+    }
+
+    @Test
+    public void testCreateTimeSpanStringNoFill() throws Exception {
+        CalendarEvent multiDayAllDay = new CalendarEvent();
+        multiDayAllDay.setAllDay(true);
+        multiDayAllDay.setStartDate(T_2015_JUL_9);
+        multiDayAllDay.setEndDate(T_2015_JUL_15);
+
+        Assert.assertEquals("→ Tue, Jul 14", createTimeSpanString(multiDayAllDay, false));
+    }
+
+    @Test
+    public void testCreateTimeSpanStringFill() throws Exception {
+        CalendarEvent multiDayAllDay = new CalendarEvent();
+        multiDayAllDay.setAllDay(true);
+        multiDayAllDay.setStartDate(T_2015_JUL_9);
+        multiDayAllDay.setEndDate(T_2015_JUL_15);
+
+        Assert.assertEquals("00:00", createTimeSpanString(multiDayAllDay, true));
+    }
+}


### PR DESCRIPTION
Before this change, when not filling all-day events, a NullPointerException was
thrown when trying to render an all-day event.

With this change in place, we don't NPE any more.

This change also comes with a regression test for the problem.