### PR TITLE
Fix Wonky All Day Event Visualization

### DIFF
--- a/app/calendar-widget/src/main/java/com/plusonelabs/calendar/calendar/CalendarEvent.java
+++ b/app/calendar-widget/src/main/java/com/plusonelabs/calendar/calendar/CalendarEvent.java
@@ -109,6 +109,12 @@ public class CalendarEvent extends Event {
 	}
 
 	public boolean spansOneFullDay() {
+		if (isAllDay() && getStartDate().isEqual(endDate)) {
+			// In some cases it's possible to get an all day event into the calendar that spans
+			// zero days (starts and ends at the same timestamp). Google Calendar's web UI renders
+			// such events as spanning one full day, so we should do that as well.
+			return true;
+		}
 		return getStartDate().plusDays(1).isEqual(endDate);
 	}
 


### PR DESCRIPTION
In some cases it's possible to get an all day event into the calendar that spans
zero days (starts and ends at the same timestamp). Google Calendar's web UI
renders such events as spanning one full day, so we should do that as well.

I have no idea how to put such events in the calendar, but I have one of them in
mine so it is possible.

Without this change, the Calendar Widget says about my event that it starts on
Sunday (correct) and ends on the day before, Saturday (wrong).

This does seem to be a corner case, because at least one other calendar app
(DigiKal) also fails at this event. In their case they render the (all day Sunday)
event as starting on Saturday (wrong) and ending on Friday (even more
wrong).