### PR TITLE
Add abbreviated day header option

### DIFF
--- a/app/calendar-widget/src/main/java/com/plusonelabs/calendar/DateUtil.java
+++ b/app/calendar-widget/src/main/java/com/plusonelabs/calendar/DateUtil.java
@@ -1,11 +1,15 @@
 package com.plusonelabs.calendar;
 
 import android.content.Context;
+import android.preference.PreferenceManager;
 import android.text.format.DateUtils;
 
 import org.joda.time.DateTime;
 
 import java.util.Date;
+
+import static com.plusonelabs.calendar.prefs.CalendarPreferences.PREF_ABBREVIATE_DATES;
+import static com.plusonelabs.calendar.prefs.CalendarPreferences.PREF_ABBREVIATE_DATES_DEFAULT;
 
 public class DateUtil {
 
@@ -19,6 +23,12 @@ public class DateUtil {
 
     public static String createDateString(Context context, DateTime dateTime) {
         DateTime timeAtStartOfToday = DateTime.now().withTimeAtStartOfDay();
+        if (PreferenceManager.getDefaultSharedPreferences(context)
+                .getBoolean(PREF_ABBREVIATE_DATES, PREF_ABBREVIATE_DATES_DEFAULT)) {
+            return DateUtils.formatDateTime(context, dateTime.toDate().getTime(),
+                    DateUtils.FORMAT_ABBREV_ALL | DateUtils.FORMAT_SHOW_DATE |
+                    DateUtils.FORMAT_SHOW_WEEKDAY);
+        }
         if (dateTime.withTimeAtStartOfDay().isEqual(timeAtStartOfToday)) {
             return createDateString(context, dateTime.toDate(), context.getString(R.string.today));
         } else if (dateTime.withTimeAtStartOfDay().isEqual(timeAtStartOfToday.plusDays(1))) {

--- a/app/calendar-widget/src/main/java/com/plusonelabs/calendar/prefs/CalendarPreferences.java
+++ b/app/calendar-widget/src/main/java/com/plusonelabs/calendar/prefs/CalendarPreferences.java
@@ -49,6 +49,8 @@ public class CalendarPreferences {
     public static final int PREF_PAST_EVENTS_BACKGROUND_COLOR_DEFAULT = 0x4affff2b;
 	public static final String PREF_HIDE_BASED_ON_KEYWORDS = "hideBasedOnKeywords";
     static final String KEY_SHARE_EVENTS_FOR_DEBUGGING = "shareEventsForDebugging";
+    public static final String PREF_ABBREVIATE_DATES = "abbreviateDates";
+    public static final boolean PREF_ABBREVIATE_DATES_DEFAULT = false;
 
     private CalendarPreferences() {
 		// prohibit instantiation
@@ -62,6 +64,7 @@ public class CalendarPreferences {
         json.put(PREF_HIDE_BASED_ON_KEYWORDS, getHideBasedOnKeywords(context));
         json.put(PREF_SHOW_DAYS_WITHOUT_EVENTS, getShowDaysWithoutEvents(context));
         json.put(PREF_SHOW_PAST_EVENTS_WITH_DEFAULT_COLOR, getShowPastEventsWithDefaultColor(context));
+        json.put(PREF_ABBREVIATE_DATES, getAbbreviateDates(context));
         return json;
     }
 
@@ -72,6 +75,7 @@ public class CalendarPreferences {
         setHideBasedOnKeywords(context, json.getString(PREF_HIDE_BASED_ON_KEYWORDS));
         setShowDaysWithoutEvents(context, json.getBoolean(PREF_SHOW_DAYS_WITHOUT_EVENTS));
         setShowPastEventsWithDefaultColor(context, json.getBoolean(PREF_SHOW_PAST_EVENTS_WITH_DEFAULT_COLOR));
+        setAbbreviateDates(context, json.getBoolean(PREF_ABBREVIATE_DATES));
     }
 
     public static Set<String> getActiveCalendars(Context context) {
@@ -173,6 +177,15 @@ public class CalendarPreferences {
     public static String getDateFormat(Context context) {
         return PreferenceManager.getDefaultSharedPreferences(context).getString(
                 PREF_DATE_FORMAT, PREF_DATE_FORMAT_DEFAULT);
+    }
+
+    public static boolean getAbbreviateDates(Context context) {
+        return PreferenceManager.getDefaultSharedPreferences(context)
+                .getBoolean(PREF_ABBREVIATE_DATES, PREF_ABBREVIATE_DATES_DEFAULT);
+    }
+
+    public static void setAbbreviateDates(Context context, boolean value) {
+        setBooleanPreference(context, PREF_ABBREVIATE_DATES, value);
     }
 
     private static void setBooleanPreference(Context context, String key, boolean value) {

--- a/app/calendar-widget/src/main/res/values/strings.xml
+++ b/app/calendar-widget/src/main/res/values/strings.xml
@@ -56,6 +56,8 @@
     <string name="appearance_theme_dark">Light</string>
     <string name="appearance_theme_light">Dark</string>
     <string name="appearance_theme_white">Black</string>
+    <string name="appearance_abbreviate_dates_title">Abbreviate dates</string>
+    <string name="appearance_abbreviate_dates_desc">Use three-letter format for day headers</string>
 
     <!-- Preference header: Event details -->
     <string name="event_details_prefs">Event details</string>

--- a/app/calendar-widget/src/main/res/xml/preferences_appearance.xml
+++ b/app/calendar-widget/src/main/res/xml/preferences_appearance.xml
@@ -45,6 +45,13 @@
         android:title="@string/appearance_display_header_title">
     </CheckBoxPreference>
 
+    <CheckBoxPreference
+        android:defaultValue="false"
+        android:key="abbreviateDates"
+        android:summary="@string/appearance_abbreviate_dates_desc"
+        android:title="@string/appearance_abbreviate_dates_title">
+    </CheckBoxPreference>
+
     <PreferenceCategory android:title="@string/appearance_group_color_title">
         <ListPreference
             android:defaultValue="DARK"


### PR DESCRIPTION
Solution for issue #231.

Adds an option on the "Appearances" preference page to toggle abbreviated date headers.

Uses DateTime's built-in abbreviation toggles to output date in three-letter format.

Only includes @strings preference text for English locales.