### PR TITLE
Adjust event color opacity/disable

### DIFF
--- a/app/calendar-widget/src/main/java/com/plusonelabs/calendar/calendar/CalendarEventProvider.java
+++ b/app/calendar-widget/src/main/java/com/plusonelabs/calendar/calendar/CalendarEventProvider.java
@@ -206,7 +206,7 @@ public class CalendarEventProvider {
         event.setLocation(cursor.getString(cursor.getColumnIndex(Instances.EVENT_LOCATION)));
         event.setAlarmActive(cursor.getInt(cursor.getColumnIndex(Instances.HAS_ALARM)) > 0);
         event.setRecurring(cursor.getString(cursor.getColumnIndex(Instances.RRULE)) != null);
-        event.setColor(getAsOpaque(getEventColor(cursor)));
+        event.setColor(getAsConfiguredOpacity(getEventColor(cursor)));
         if (event.isAllDay()) {
             fixAllDayEvent(event);
         }
@@ -266,5 +266,13 @@ public class CalendarEventProvider {
 
     private int getAsOpaque(int color) {
         return argb(255, red(color), green(color), blue(color));
+    }
+
+    private int getAsConfiguredOpacity(int color) {
+        if (CalendarPreferences.getEventColorOpacity(context) ==
+                CalendarPreferences.PREF_EVENT_COLOR_OPACITY_DISABLED) {
+            return argb(0, red(color), green(color), blue(color));
+        }
+        return argb(CalendarPreferences.getEventColorOpacity(context), red(color), green(color), blue(color));
     }
 }

--- a/app/calendar-widget/src/main/java/com/plusonelabs/calendar/calendar/CalendarEventVisualizer.java
+++ b/app/calendar-widget/src/main/java/com/plusonelabs/calendar/calendar/CalendarEventVisualizer.java
@@ -55,7 +55,7 @@ public class CalendarEventVisualizer implements IEventVisualizer<CalendarEntry> 
 		setEventDetails(event, rv);
 		setAlarmActive(event, rv);
         setRecurring(event, rv);
-		setColor(event, rv);
+		setColor(event, R.id.event_entry_color, rv);
 		return rv;
 	}
 
@@ -104,10 +104,14 @@ public class CalendarEventVisualizer implements IEventVisualizer<CalendarEntry> 
         }
     }
 
-    private void setColor(CalendarEntry entry, RemoteViews rv) {
+    private void setColor(CalendarEntry entry, int viewId, RemoteViews rv) {
         setBackgroundColor(rv, R.id.event_entry_color, entry.getColor());
+        rv.setViewVisibility(viewId, View.VISIBLE);
         if (entry.getEndDate().isBefore(DateUtil.now())) {
             setBackgroundColor(rv, R.id.event_entry, CalendarPreferences.getPastEventsBackgroundColor(context));
+        } else if (CalendarPreferences.getEventColorOpacity(context) ==
+                CalendarPreferences.PREF_EVENT_COLOR_OPACITY_DISABLED) {
+            rv.setViewVisibility(viewId, View.GONE);
         } else {
             setBackgroundColor(rv, R.id.event_entry, 0);
         }

--- a/app/calendar-widget/src/main/java/com/plusonelabs/calendar/prefs/AppearancePreferencesFragment.java
+++ b/app/calendar-widget/src/main/java/com/plusonelabs/calendar/prefs/AppearancePreferencesFragment.java
@@ -37,6 +37,10 @@ public class AppearancePreferencesFragment extends PreferenceFragment {
             new BackgroundTransparencyDialog().show(getFragmentManager(),
                     CalendarPreferences.PREF_PAST_EVENTS_BACKGROUND_COLOR);
         }
+/*		if (preference.getKey().equals(CalendarPreferences.PREF_EVENT_COLOR_OPACITY)) {
+			new OpacitySlider().show(getFragmentManager(),
+					CalendarPreferences.PREF_EVENT_COLOR_OPACITY);
+		} */// TODO: Implement OpacitySlider for variable event color opacity setting
 		return super.onPreferenceTreeClick(preferenceScreen, preference);
 	}
 

--- a/app/calendar-widget/src/main/java/com/plusonelabs/calendar/prefs/CalendarPreferences.java
+++ b/app/calendar-widget/src/main/java/com/plusonelabs/calendar/prefs/CalendarPreferences.java
@@ -49,6 +49,9 @@ public class CalendarPreferences {
     public static final int PREF_PAST_EVENTS_BACKGROUND_COLOR_DEFAULT = 0x4affff2b;
 	public static final String PREF_HIDE_BASED_ON_KEYWORDS = "hideBasedOnKeywords";
     static final String KEY_SHARE_EVENTS_FOR_DEBUGGING = "shareEventsForDebugging";
+    public static final String PREF_EVENT_COLOR_OPACITY = "eventColorOpacity";
+    public static final String PREF_EVENT_COLOR_OPACITY_DEFAULT = "255";
+    public static final int PREF_EVENT_COLOR_OPACITY_DISABLED = -1;
 
     private CalendarPreferences() {
 		// prohibit instantiation
@@ -173,6 +176,11 @@ public class CalendarPreferences {
     public static String getDateFormat(Context context) {
         return PreferenceManager.getDefaultSharedPreferences(context).getString(
                 PREF_DATE_FORMAT, PREF_DATE_FORMAT_DEFAULT);
+    }
+
+    public static int getEventColorOpacity(Context context) {
+        return Integer.valueOf(PreferenceManager.getDefaultSharedPreferences(context)
+                .getString(PREF_EVENT_COLOR_OPACITY, PREF_EVENT_COLOR_OPACITY_DEFAULT));
     }
 
     private static void setBooleanPreference(Context context, String key, boolean value) {

--- a/app/calendar-widget/src/main/res/layout/event_entry.xml
+++ b/app/calendar-widget/src/main/res/layout/event_entry.xml
@@ -11,6 +11,7 @@
     <TextView
         android:id="@+id/event_entry_color"
         style="@style/EventEntryColor"
+        android:visibility="visible"
         android:layout_width="8dp"
         android:layout_height="fill_parent"
         tools:ignore="SelectableText" />

--- a/app/calendar-widget/src/main/res/values/arrays.xml
+++ b/app/calendar-widget/src/main/res/values/arrays.xml
@@ -85,4 +85,16 @@
         <item>TODAY</item>
         <item>YESTERDAY</item>
     </string-array>
+    <string-array name="pref_event_color_opacity_entries">
+        <item>@string/one_hundred_percent</item>
+        <item>@string/fifty_percent</item>
+        <item>@string/zero_percent</item>
+        <item>@string/disable</item>
+    </string-array>
+    <string-array name="pref_event_color_opacity_values" tools:ignore="MissingTranslation">
+        <item>255</item>
+        <item>127</item>
+        <item>0</item>
+        <item>-1</item>
+    </string-array>
 </resources>

--- a/app/calendar-widget/src/main/res/values/strings.xml
+++ b/app/calendar-widget/src/main/res/values/strings.xml
@@ -56,6 +56,8 @@
     <string name="appearance_theme_dark">Light</string>
     <string name="appearance_theme_light">Dark</string>
     <string name="appearance_theme_white">Black</string>
+    <string name="appearance_event_color_opacity_desc">Adjust opacity of event color bars</string>
+    <string name="appearance_event_color_opacity_title">Event color opacity</string>
 
     <!-- Preference header: Event details -->
     <string name="event_details_prefs">Event details</string>
@@ -98,6 +100,10 @@
     <string name="ended_today">Ended today</string>
     <string name="ended_yesterday">Ended yesterday</string>
     <string name="pref_hide_based_on_keywords_title">Hide based on keywords in a title</string>
+    <string name="one_hundred_percent">100%</string>
+    <string name="fifty_percent">50%</string>
+    <string name="zero_percent">0%</string>
+    <string name="disable">Disable</string>
 
     <!-- Preference header: Feedback -->
     <string name="feedback_prefs">Feedback</string>

--- a/app/calendar-widget/src/main/res/xml/preferences_appearance.xml
+++ b/app/calendar-widget/src/main/res/xml/preferences_appearance.xml
@@ -73,6 +73,15 @@
             android:key="entryTheme"
             android:summary="@string/appearance_entries_theme_desc"
             android:title="@string/appearance_entries_theme_title" />
+
+        <ListPreference
+            android:defaultValue="255"
+            android:entries="@array/pref_event_color_opacity_entries"
+            android:entryValues="@array/pref_event_color_opacity_values"
+            android:key="eventColorOpacity"
+            android:summary="@string/appearance_event_color_opacity_desc"
+            android:title="@string/appearance_event_color_opacity_title">
+        </ListPreference>
     </PreferenceCategory>
 
 </PreferenceScreen>


### PR DESCRIPTION
Solves issue #174.

Adds Appearance preference option to change event color opacity to 100%, 50%, 0%, or Disable. Percentages affect alpha value and leaves space reserved, "Disable" sets the bar to "GONE" leaving a more condensed layout for narrow widget sizes.

Only includes English locale strings.
