### PR TITLE
Add option to disable day headers completely.

### DIFF
--- a/app/calendar-widget/src/androidTest/java/com/plusonelabs/calendar/calendar/MockCalendarContentProvider.java
+++ b/app/calendar-widget/src/androidTest/java/com/plusonelabs/calendar/calendar/MockCalendarContentProvider.java
@@ -67,6 +67,7 @@ public class MockCalendarContentProvider extends MockContentProvider {
         CalendarPreferences.fromJson(context,
                 new JSONObject("{" +
                         " \"showDaysWithoutEvents\": false," +
+                        " \"showDayHeaders\": true," +
                         " \"hideBasedOnKeywords\": \"\"," +
                         " \"eventRange\": 30," +
                         " \"showPastEventsWithDefaultColor\": false," +

--- a/app/calendar-widget/src/main/java/com/plusonelabs/calendar/EventRemoteViewsFactory.java
+++ b/app/calendar-widget/src/main/java/com/plusonelabs/calendar/EventRemoteViewsFactory.java
@@ -94,7 +94,7 @@ public class EventRemoteViewsFactory implements RemoteViewsFactory {
 
     public void onDataSetChanged() {
         context.setTheme(getCurrentThemeId(context, PREF_ENTRY_THEME, PREF_ENTRY_THEME_DEFAULT));
-        if (CalendarPreferences.getShowDayEntries(context))
+        if (CalendarPreferences.getShowDayHeaders(context))
             mWidgetEntries = addDayHeaders(getEventEntries());
         else
             mWidgetEntries = getEventEntries();

--- a/app/calendar-widget/src/main/java/com/plusonelabs/calendar/EventRemoteViewsFactory.java
+++ b/app/calendar-widget/src/main/java/com/plusonelabs/calendar/EventRemoteViewsFactory.java
@@ -94,7 +94,10 @@ public class EventRemoteViewsFactory implements RemoteViewsFactory {
 
     public void onDataSetChanged() {
         context.setTheme(getCurrentThemeId(context, PREF_ENTRY_THEME, PREF_ENTRY_THEME_DEFAULT));
-        mWidgetEntries = addDayHeaders(getEventEntries());
+        if (CalendarPreferences.getShowDayEntries(context))
+            mWidgetEntries = addDayHeaders(getEventEntries());
+        else
+            mWidgetEntries = getEventEntries();
     }
 
     private List<WidgetEntry> getEventEntries() {

--- a/app/calendar-widget/src/main/java/com/plusonelabs/calendar/prefs/CalendarPreferences.java
+++ b/app/calendar-widget/src/main/java/com/plusonelabs/calendar/prefs/CalendarPreferences.java
@@ -25,7 +25,7 @@ public class CalendarPreferences {
 	public static final boolean PREF_MULTILINE_TITLE_DEFAULT = false;
 	private static final String PREF_ACTIVE_CALENDARS = "activeCalendars";
 	private static final String PREF_SHOW_DAYS_WITHOUT_EVENTS = "showDaysWithoutEvents";
-	private static final String PREF_SHOW_DAY_ENTRIES = "showDayEntries";
+	private static final String PREF_SHOW_DAY_HEADERS = "showDayHeaders";
 	public static final String PREF_SHOW_HEADER = "showHeader";
 	public static final String PREF_INDICATE_RECURRING = "indicateRecurring";
 	public static final String PREF_INDICATE_ALERTS = "indicateAlerts";
@@ -71,7 +71,7 @@ public class CalendarPreferences {
         json.put(PREF_FILL_ALL_DAY, getFillAllDayEvents(context));
         json.put(PREF_HIDE_BASED_ON_KEYWORDS, getHideBasedOnKeywords(context));
         json.put(PREF_SHOW_DAYS_WITHOUT_EVENTS, getShowDaysWithoutEvents(context));
-        json.put(PREF_SHOW_DAY_ENTRIES, getShowDayEntries(context));
+        json.put(PREF_SHOW_DAY_HEADERS, getShowDayHeaders(context));
         json.put(PREF_SHOW_PAST_EVENTS_WITH_DEFAULT_COLOR, getShowPastEventsWithDefaultColor(context));
         json.put(PREF_ABBREVIATE_DATES, getAbbreviateDates(context));
         return json;
@@ -83,7 +83,7 @@ public class CalendarPreferences {
         setFillAllDayEvents(context, json.getBoolean(PREF_FILL_ALL_DAY));
         setHideBasedOnKeywords(context, json.getString(PREF_HIDE_BASED_ON_KEYWORDS));
         setShowDaysWithoutEvents(context, json.getBoolean(PREF_SHOW_DAYS_WITHOUT_EVENTS));
-        setShowDayEntries(context, json.getBoolean(PREF_SHOW_DAY_ENTRIES));
+        setShowDayHeaders(context, json.getBoolean(PREF_SHOW_DAY_HEADERS));
         setShowPastEventsWithDefaultColor(context, json.getBoolean(PREF_SHOW_PAST_EVENTS_WITH_DEFAULT_COLOR));
         setAbbreviateDates(context, json.getBoolean(PREF_ABBREVIATE_DATES));
     }
@@ -161,13 +161,13 @@ public class CalendarPreferences {
         setBooleanPreference(context, PREF_SHOW_DAYS_WITHOUT_EVENTS, value);
     }
 
-    public static boolean getShowDayEntries(Context context) {
+    public static boolean getShowDayHeaders(Context context) {
         return PreferenceManager.getDefaultSharedPreferences(context)
-                .getBoolean(PREF_SHOW_DAY_ENTRIES, true);
+                .getBoolean(PREF_SHOW_DAY_HEADERS, true);
     }
 
-    private static void setShowDayEntries(Context context, boolean value) {
-        setBooleanPreference(context, PREF_SHOW_DAY_ENTRIES, value);
+    private static void setShowDayHeaders(Context context, boolean value) {
+        setBooleanPreference(context, PREF_SHOW_DAY_HEADERS, value);
     }
 
     public static boolean getShowPastEventsWithDefaultColor(Context context) {

--- a/app/calendar-widget/src/main/java/com/plusonelabs/calendar/prefs/CalendarPreferences.java
+++ b/app/calendar-widget/src/main/java/com/plusonelabs/calendar/prefs/CalendarPreferences.java
@@ -25,6 +25,7 @@ public class CalendarPreferences {
 	public static final boolean PREF_MULTILINE_TITLE_DEFAULT = false;
 	private static final String PREF_ACTIVE_CALENDARS = "activeCalendars";
 	private static final String PREF_SHOW_DAYS_WITHOUT_EVENTS = "showDaysWithoutEvents";
+	private static final String PREF_SHOW_DAY_ENTRIES = "showDayEntries";
 	public static final String PREF_SHOW_HEADER = "showHeader";
 	public static final String PREF_INDICATE_RECURRING = "indicateRecurring";
 	public static final String PREF_INDICATE_ALERTS = "indicateAlerts";
@@ -70,6 +71,7 @@ public class CalendarPreferences {
         json.put(PREF_FILL_ALL_DAY, getFillAllDayEvents(context));
         json.put(PREF_HIDE_BASED_ON_KEYWORDS, getHideBasedOnKeywords(context));
         json.put(PREF_SHOW_DAYS_WITHOUT_EVENTS, getShowDaysWithoutEvents(context));
+        json.put(PREF_SHOW_DAY_ENTRIES, getShowDayEntries(context));
         json.put(PREF_SHOW_PAST_EVENTS_WITH_DEFAULT_COLOR, getShowPastEventsWithDefaultColor(context));
         json.put(PREF_ABBREVIATE_DATES, getAbbreviateDates(context));
         return json;
@@ -81,6 +83,7 @@ public class CalendarPreferences {
         setFillAllDayEvents(context, json.getBoolean(PREF_FILL_ALL_DAY));
         setHideBasedOnKeywords(context, json.getString(PREF_HIDE_BASED_ON_KEYWORDS));
         setShowDaysWithoutEvents(context, json.getBoolean(PREF_SHOW_DAYS_WITHOUT_EVENTS));
+        setShowDayEntries(context, json.getBoolean(PREF_SHOW_DAY_ENTRIES));
         setShowPastEventsWithDefaultColor(context, json.getBoolean(PREF_SHOW_PAST_EVENTS_WITH_DEFAULT_COLOR));
         setAbbreviateDates(context, json.getBoolean(PREF_ABBREVIATE_DATES));
     }
@@ -158,6 +161,15 @@ public class CalendarPreferences {
         setBooleanPreference(context, PREF_SHOW_DAYS_WITHOUT_EVENTS, value);
     }
 
+    public static boolean getShowDayEntries(Context context) {
+        return PreferenceManager.getDefaultSharedPreferences(context)
+                .getBoolean(PREF_SHOW_DAY_ENTRIES, true);
+    }
+
+    private static void setShowDayEntries(Context context, boolean value) {
+        setBooleanPreference(context, PREF_SHOW_DAY_ENTRIES, value);
+    }
+
     public static boolean getShowPastEventsWithDefaultColor(Context context) {
         return PreferenceManager.getDefaultSharedPreferences(context)
                 .getBoolean(PREF_SHOW_PAST_EVENTS_WITH_DEFAULT_COLOR, false);
@@ -215,5 +227,4 @@ public class CalendarPreferences {
     public static boolean isTimeZoneLocked(Context context) {
         return !TextUtils.isEmpty(getLockedTimeZoneId(context));
     }
-
 }

--- a/app/calendar-widget/src/main/res/values/strings.xml
+++ b/app/calendar-widget/src/main/res/values/strings.xml
@@ -40,8 +40,8 @@
     <string name="appearance_date_format_12">5:00 pm</string>
     <string name="appearance_show_days_without_events_title">Show days without events</string>
     <string name="appearance_show_days_without_events_desc">Show day headers for days without events</string>
-    <string name="appearance_show_day_entries_title">Show day headers</string>
-    <string name="appearance_show_day_entries_desc">Show day headers at all</string>
+    <string name="appearance_show_day_headers_title">Show day headers</string>
+    <string name="appearance_show_day_headers_desc">Show day headers at all</string>
     <string name="appearance_display_header_title">Show widget header</string>
     <string name="appearance_display_header_desc">Show the date and settings header</string>
     <string name="appearance_display_header_warning">Hiding the header also stops you from getting back into the preferences.</string>

--- a/app/calendar-widget/src/main/res/values/strings.xml
+++ b/app/calendar-widget/src/main/res/values/strings.xml
@@ -40,6 +40,8 @@
     <string name="appearance_date_format_12">5:00 pm</string>
     <string name="appearance_show_days_without_events_title">Show days without events</string>
     <string name="appearance_show_days_without_events_desc">Show day headers for days without events</string>
+    <string name="appearance_show_day_entries_title">Show day headers</string>
+    <string name="appearance_show_day_entries_desc">Show day headers at all</string>
     <string name="appearance_display_header_title">Show widget header</string>
     <string name="appearance_display_header_desc">Show the date and settings header</string>
     <string name="appearance_display_header_warning">Hiding the header also stops you from getting back into the preferences.</string>

--- a/app/calendar-widget/src/main/res/xml/preferences_appearance.xml
+++ b/app/calendar-widget/src/main/res/xml/preferences_appearance.xml
@@ -27,14 +27,14 @@
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:defaultValue="true"
-        android:key="showDayEntries"
-        android:summary="@string/appearance_show_day_entries_desc"
-        android:title="@string/appearance_show_day_entries_title">
+        android:key="showDayHeaders"
+        android:summary="@string/appearance_show_day_headers_desc"
+        android:title="@string/appearance_show_day_headers_title">
     </CheckBoxPreference>
 
     <ListPreference
         android:defaultValue="RIGHT"
-        android:dependency="showDayEntries"
+        android:dependency="showDayHeaders"
         android:entries="@array/pref_day_header_alignment_entries"
         android:entryValues="@array/pref_day_header_alignment_values"
         android:key="dayHeaderAlignment"
@@ -43,7 +43,7 @@
 
     <CheckBoxPreference
         android:defaultValue="false"
-        android:dependency="showDayEntries"
+        android:dependency="showDayHeaders"
         android:key="showDaysWithoutEvents"
         android:summary="@string/appearance_show_days_without_events_desc"
         android:title="@string/appearance_show_days_without_events_title">

--- a/app/calendar-widget/src/main/res/xml/preferences_appearance.xml
+++ b/app/calendar-widget/src/main/res/xml/preferences_appearance.xml
@@ -23,8 +23,18 @@
         android:summary="@string/appearance_date_format_desc"
         android:title="@string/appearance_date_format_title" />
 
+    <CheckBoxPreference
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:defaultValue="true"
+        android:key="showDayEntries"
+        android:summary="@string/appearance_show_day_entries_desc"
+        android:title="@string/appearance_show_day_entries_title">
+    </CheckBoxPreference>
+
     <ListPreference
         android:defaultValue="RIGHT"
+        android:dependency="showDayEntries"
         android:entries="@array/pref_day_header_alignment_entries"
         android:entryValues="@array/pref_day_header_alignment_values"
         android:key="dayHeaderAlignment"
@@ -33,6 +43,7 @@
 
     <CheckBoxPreference
         android:defaultValue="false"
+        android:dependency="showDayEntries"
         android:key="showDaysWithoutEvents"
         android:summary="@string/appearance_show_days_without_events_desc"
         android:title="@string/appearance_show_days_without_events_title">


### PR DESCRIPTION
I have the widget configured to only display my agenda for the day, and I found the date headers only take up additional space without really adding any new information. So, I added an option to remove them. This is primarily something I made for myself, but figured other people might be interested too