### PR TITLE
Extend filtering: negations, calendar-specific regular expressions

### DIFF
--- a/app/src/androidTest/java/org/andstatus/todoagenda/calendar/KeywordsFilterTest.java
+++ b/app/src/androidTest/java/org/andstatus/todoagenda/calendar/KeywordsFilterTest.java
@@ -29,6 +29,13 @@ public class KeywordsFilterTest extends InstrumentationTestCase {
         assertMatch(query3, "Smith's Birthday");
         assertMatch(query3, "Smith Hidden Birthday");
         assertNotMatch(query3, "Smith.Birthday");
+
+        assertMatch("RE:CAL=.*;TITLE=John.*", "John Smith's Birthday");
+        assertMatch("RE:CAL=.*;TITLE=.*Smith.*", "John Smith's Birthday");
+        assertNotMatch("RE:CAL=wrong_cal_name;TITLE=.*", "John Smith's Birthday");
+        assertNotMatch("!RE:CAL=.*;TITLE=.*", "John Smith's Birthday");
+        assertNotMatch("! John Miller", "John Smith's Birthday");
+        assertMatch("! Jack Miller", "John Smith's Birthday");
     }
 
     private void assertOneQueryToKeywords(String query, String... keywords) {
@@ -41,10 +48,10 @@ public class KeywordsFilterTest extends InstrumentationTestCase {
     }
 
     private void assertMatch(String query, String body) {
-        assertTrue("no keywords from '" + query + "' match: '" + body + "'", new KeywordsFilter(query).matched(body));
+        assertTrue("no keywords from '" + query + "' match: '" + body + "'", new KeywordsFilter(query).matched(body, "cal_name"));
     }
 
     private void assertNotMatch(String query, String body) {
-        assertFalse("Some keyword from '" + query + "' match: '" + body + "'", new KeywordsFilter(query).matched(body));
+        assertFalse("Some keyword from '" + query + "' match: '" + body + "'", new KeywordsFilter(query).matched(body, "cal_name"));
     }
 }

--- a/app/src/main/java/org/andstatus/todoagenda/calendar/CalendarEventProvider.java
+++ b/app/src/main/java/org/andstatus/todoagenda/calendar/CalendarEventProvider.java
@@ -176,7 +176,8 @@ public class CalendarEventProvider {
                         result.addRow(cursor);
                     }
                     CalendarEvent event = createCalendarEvent(cursor);
-                    if (!eventList.contains(event) && !mKeywordsFilter.matched(event.getTitle())) {
+                    if (!eventList.contains(event) && !mKeywordsFilter.matched(event.getTitle(),
+                            cursor.getString(cursor.getColumnIndex(Instances.CALENDAR_DISPLAY_NAME)))) {
                         eventList.add(event);
                     }
                 }
@@ -200,6 +201,7 @@ public class CalendarEventProvider {
         columnNames.add(Instances.EVENT_LOCATION);
         columnNames.add(Instances.HAS_ALARM);
         columnNames.add(Instances.RRULE);
+        columnNames.add(Instances.CALENDAR_DISPLAY_NAME);
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.JELLY_BEAN) {
             columnNames.add(Instances.DISPLAY_COLOR);
         } else {


### PR DESCRIPTION
Allow to filter events based on
- negations (e.g., "!Birthday" filters everything out except birthdays),
- calendar-specific regular expressions (e.g.,
    "RE:CAL=cal1;TITLE=.*[wW]ork.*"
  filters out all events in calendar "cal1" that contain the word "work"
  or "Work").