### PR TITLE
Adds tasks/TODOs support

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -4,6 +4,7 @@
           android:installLocation="internalOnly">
 
     <uses-permission android:name="android.permission.READ_CALENDAR"/>
+    <uses-permission android:name="org.dmfs.permission.READ_TASKS"/>
 
     <application
         android:allowBackup="true"

--- a/app/src/main/java/org/andstatus/todoagenda/EventProvider.java
+++ b/app/src/main/java/org/andstatus/todoagenda/EventProvider.java
@@ -1,0 +1,53 @@
+package org.andstatus.todoagenda;
+
+import android.content.Context;
+import android.support.annotation.NonNull;
+import org.andstatus.todoagenda.calendar.KeywordsFilter;
+import org.andstatus.todoagenda.prefs.InstanceSettings;
+import org.joda.time.DateTime;
+import org.joda.time.DateTimeZone;
+
+public abstract class EventProvider {
+
+    protected static final String AND_BRACKET = " AND (";
+    protected static final String CLOSING_BRACKET = " )";
+    protected static final String AND = " AND ";
+    protected static final String OR = " OR ";
+    protected static final String EQUALS = " = ";
+    protected static final String NOT_EQUALS = " != ";
+    protected static final String LTE = " <= ";
+    protected static final String IS_NULL = " IS NULL";
+
+    protected final Context context;
+    protected final int widgetId;
+
+    // Below are parameters, which may change in settings
+    protected DateTimeZone zone;
+    protected KeywordsFilter mKeywordsFilter;
+    protected DateTime mStartOfTimeRange;
+    protected DateTime mEndOfTimeRange;
+
+    public EventProvider(Context context, int widgetId) {
+        this.context = context;
+        this.widgetId = widgetId;
+    }
+
+    protected void initialiseParameters() {
+        zone = getSettings().getTimeZone();
+        mKeywordsFilter = new KeywordsFilter(getSettings().getHideBasedOnKeywords());
+        mStartOfTimeRange = getSettings().getEventsEnded().endedAt(DateUtil.now(zone));
+        mEndOfTimeRange = getEndOfTimeRange(DateUtil.now(zone));
+    }
+
+    private DateTime getEndOfTimeRange(DateTime now) {
+        int dateRange = getSettings().getEventRange();
+        return dateRange > 0
+                ? now.plusDays(dateRange)
+                : now.withTimeAtStartOfDay().plusDays(1);
+    }
+
+    @NonNull
+    protected InstanceSettings getSettings() {
+        return InstanceSettings.fromId(context, widgetId);
+    }
+}

--- a/app/src/main/java/org/andstatus/todoagenda/EventRemoteViewsFactory.java
+++ b/app/src/main/java/org/andstatus/todoagenda/EventRemoteViewsFactory.java
@@ -10,12 +10,14 @@ import android.widget.RemoteViewsService.RemoteViewsFactory;
 
 import org.andstatus.todoagenda.calendar.CalendarEventVisualizer;
 import org.andstatus.todoagenda.prefs.InstanceSettings;
+import org.andstatus.todoagenda.task.TaskVisualizer;
 import org.andstatus.todoagenda.widget.DayHeader;
 import org.andstatus.todoagenda.widget.WidgetEntry;
 
 import org.joda.time.DateTime;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 import java.util.Locale;
 
@@ -35,6 +37,7 @@ public class EventRemoteViewsFactory implements RemoteViewsFactory {
         this.widgetId = widgetId;
         eventProviders = new ArrayList<>();
         eventProviders.add(new CalendarEventVisualizer(context, widgetId));
+        eventProviders.add(new TaskVisualizer(context, widgetId));
     }
 
     public void onCreate() {
@@ -103,6 +106,7 @@ public class EventRemoteViewsFactory implements RemoteViewsFactory {
         for (IEventVisualizer<?> eventProvider : eventProviders) {
             entries.addAll(eventProvider.getEventEntries());
         }
+        Collections.sort(entries);
         return entries;
     }
 

--- a/app/src/main/java/org/andstatus/todoagenda/calendar/CalendarEventProvider.java
+++ b/app/src/main/java/org/andstatus/todoagenda/calendar/CalendarEventProvider.java
@@ -11,11 +11,9 @@ import android.support.annotation.NonNull;
 import android.util.SparseArray;
 
 import org.andstatus.todoagenda.DateUtil;
-import org.andstatus.todoagenda.prefs.InstanceSettings;
+import org.andstatus.todoagenda.EventProvider;
 import org.andstatus.todoagenda.util.PermissionsUtil;
-
 import org.joda.time.DateTime;
-import org.joda.time.DateTimeZone;
 
 import java.util.ArrayList;
 import java.util.Iterator;
@@ -27,28 +25,14 @@ import static android.graphics.Color.blue;
 import static android.graphics.Color.green;
 import static android.graphics.Color.red;
 
-public class CalendarEventProvider {
+public class CalendarEventProvider extends EventProvider {
 
     public static final String EVENT_SORT_ORDER = "startDay ASC, allDay DESC, begin ASC ";
     private static final String EVENT_SELECTION = Instances.SELF_ATTENDEE_STATUS + "!="
             + Attendees.ATTENDEE_STATUS_DECLINED;
-    private static final String CLOSING_BRACKET = " )";
-    private static final String OR = " OR ";
-    private static final String EQUALS = " = ";
-    private static final String AND_BRACKET = " AND (";
-
-    private final Context context;
-    private final int widgetId;
-
-    // Below are parameters, which may change in settings
-    private DateTimeZone zone;
-    private KeywordsFilter mKeywordsFilter;
-    private DateTime mStartOfTimeRange;
-    private DateTime mEndOfTimeRange;
 
     public CalendarEventProvider(Context context, int widgetId) {
-        this.context = context;
-        this.widgetId = widgetId;
+        super(context, widgetId);
     }
 
     public List<CalendarEvent> getEvents() {
@@ -95,31 +79,12 @@ public class CalendarEventProvider {
         eventList.removeAll(toDelete);
     }
 
-    private void initialiseParameters() {
-        zone = getSettings().getTimeZone();
-        mKeywordsFilter = new KeywordsFilter(getSettings().getHideBasedOnKeywords());
-        mStartOfTimeRange = getSettings().getEventsEnded().endedAt(DateUtil.now(zone));
-        mEndOfTimeRange = getEndOfTimeRange(DateUtil.now(zone));
-    }
-
     public DateTime getEndOfTimeRange() {
         return mEndOfTimeRange;
     }
 
     public DateTime getStartOfTimeRange() {
         return mStartOfTimeRange;
-    }
-
-    private DateTime getEndOfTimeRange(DateTime now) {
-        int dateRange = getSettings().getEventRange();
-        return dateRange > 0
-                ? now.plusDays(dateRange)
-                : now.withTimeAtStartOfDay().plusDays(1);
-    }
-
-    @NonNull
-    private InstanceSettings getSettings() {
-        return InstanceSettings.fromId(context, widgetId);
     }
 
     private List<CalendarEvent> getTimeFilteredEventList() {

--- a/app/src/main/java/org/andstatus/todoagenda/prefs/ApplicationPreferences.java
+++ b/app/src/main/java/org/andstatus/todoagenda/prefs/ApplicationPreferences.java
@@ -58,6 +58,9 @@ public class ApplicationPreferences {
     static final String PREF_EVENT_ENTRY_LAYOUT = "eventEntryLayout";
     static final String PREF_SHOW_ONLY_CLOSEST_INSTANCE_OF_RECURRING_EVENT =
             "showOnlyClosestInstanceOfRecurringEvent";
+    static final String PREF_TASK_SOURCE = "taskSource";
+    static final String PREF_TASK_SOURCE_DEFAULT = "NONE";
+    static final String KEY_PREF_GRANT_TASK_PERMISSION = "grantTaskPermission";
     static final String PREF_WIDGET_INSTANCE_NAME = "widgetInstanceName";
 
     private static volatile String lockedTimeZoneId = null;
@@ -258,6 +261,10 @@ public class ApplicationPreferences {
 
     public static void setShowOnlyClosestInstanceOfRecurringEvent(Context context, boolean value) {
         setBoolean(context, PREF_SHOW_ONLY_CLOSEST_INSTANCE_OF_RECURRING_EVENT, value);
+    }
+
+    public static String getTaskSource(Context context) {
+        return getString(context, PREF_TASK_SOURCE, PREF_DATE_FORMAT_DEFAULT);
     }
 
     private static void setString(Context context, String key, String value) {

--- a/app/src/main/java/org/andstatus/todoagenda/prefs/InstanceSettings.java
+++ b/app/src/main/java/org/andstatus/todoagenda/prefs/InstanceSettings.java
@@ -68,6 +68,7 @@ public class InstanceSettings {
     private int backgroundColor = PREF_BACKGROUND_COLOR_DEFAULT;
     private String textSizeScale = PREF_TEXT_SIZE_SCALE_DEFAULT;
     private String dayHeaderAlignment = PREF_DAY_HEADER_ALIGNMENT_DEFAULT;
+    private String taskSource = PREF_TASK_SOURCE_DEFAULT;
 
     @NonNull
     public static InstanceSettings fromId(Context context, Integer widgetId) {
@@ -213,6 +214,9 @@ public class InstanceSettings {
         if (json.has(PREF_DAY_HEADER_ALIGNMENT)) {
             settings.dayHeaderAlignment = json.getString(PREF_DAY_HEADER_ALIGNMENT);
         }
+        if (json.has(PREF_TASK_SOURCE)) {
+            settings.taskSource = json.getString(PREF_TASK_SOURCE);
+        }
         return settings;
     }
 
@@ -273,6 +277,7 @@ public class InstanceSettings {
                 PREF_TEXT_SIZE_SCALE_DEFAULT);
         settings.dayHeaderAlignment = ApplicationPreferences.getString(context, PREF_DAY_HEADER_ALIGNMENT,
                 PREF_DAY_HEADER_ALIGNMENT_DEFAULT);
+        settings.taskSource = ApplicationPreferences.getTaskSource(context);
         return settings;
     }
 
@@ -365,6 +370,7 @@ public class InstanceSettings {
             json.put(PREF_BACKGROUND_COLOR, backgroundColor);
             json.put(PREF_TEXT_SIZE_SCALE, textSizeScale);
             json.put(PREF_DAY_HEADER_ALIGNMENT, dayHeaderAlignment);
+            json.put(PREF_TASK_SOURCE, taskSource);
         } catch (JSONException e) {
             throw new RuntimeException("Saving settings to JSON", e);
         }
@@ -526,6 +532,10 @@ public class InstanceSettings {
 
     public String getDayHeaderAlignment() {
         return dayHeaderAlignment;
+    }
+
+    public String getTaskSource() {
+        return taskSource;
     }
 
     public static Map<Integer, InstanceSettings> getInstances(Context context) {

--- a/app/src/main/java/org/andstatus/todoagenda/prefs/TaskPreferencesFragment.java
+++ b/app/src/main/java/org/andstatus/todoagenda/prefs/TaskPreferencesFragment.java
@@ -1,0 +1,87 @@
+package org.andstatus.todoagenda.prefs;
+
+import android.content.SharedPreferences;
+import android.os.Bundle;
+import android.preference.ListPreference;
+import android.preference.Preference;
+import android.preference.PreferenceFragment;
+import android.preference.PreferenceScreen;
+
+import org.andstatus.todoagenda.EventAppWidgetProvider;
+import org.andstatus.todoagenda.R;
+import org.andstatus.todoagenda.task.TaskProvider;
+
+public class TaskPreferencesFragment extends PreferenceFragment implements SharedPreferences.OnSharedPreferenceChangeListener {
+
+    @Override
+    public void onCreate(Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+        addPreferencesFromResource(R.xml.preferences_task);
+        setGrantPermissionVisibility(false);
+    }
+
+    @Override
+    public void onResume() {
+        super.onResume();
+        showTaskSource();
+        getPreferenceManager().getSharedPreferences().registerOnSharedPreferenceChangeListener(this);
+    }
+
+    @Override
+    public void onPause() {
+        super.onPause();
+        getPreferenceManager().getSharedPreferences().unregisterOnSharedPreferenceChangeListener(this);
+        EventAppWidgetProvider.updateEventList(getActivity());
+        EventAppWidgetProvider.updateAllWidgets(getActivity());
+    }
+
+    @Override
+    public void onSharedPreferenceChanged(SharedPreferences sharedPreferences, String key) {
+        switch (key) {
+            case ApplicationPreferences.PREF_TASK_SOURCE:
+                showTaskSource();
+                setGrantPermissionVisibility(true);
+                break;
+        }
+    }
+
+    private void showTaskSource() {
+        ListPreference preference = (ListPreference) findPreference(ApplicationPreferences.PREF_TASK_SOURCE);
+        preference.setSummary(preference.getEntry());
+    }
+
+    private void setGrantPermissionVisibility(boolean forceDisplay) {
+        TaskProvider taskProvider = new TaskProvider(getActivity(), ApplicationPreferences.getWidgetId(getActivity()));
+        if (taskProvider.hasPermission()) {
+            Preference preference = findPreference("grantTaskPermission");
+            if (preference != null) {
+                PreferenceScreen screen = getPreferenceScreen();
+                screen.removePreference(preference);
+            }
+        } else {
+            if (forceDisplay) {
+                getActivity().recreate();
+            }
+        }
+    }
+
+    @Override
+    public boolean onPreferenceTreeClick(PreferenceScreen preferenceScreen, Preference preference) {
+        switch (preference.getKey()) {
+            case ApplicationPreferences.KEY_PREF_GRANT_TASK_PERMISSION:
+                requestTaskPermission();
+                return true;
+        }
+
+        return super.onPreferenceTreeClick(preferenceScreen, preference);
+    }
+
+    private void requestTaskPermission() {
+        TaskProvider taskProvider = new TaskProvider(getActivity(), ApplicationPreferences.getWidgetId(getActivity()));
+        taskProvider.requestPermission(getActivity());
+    }
+
+    public void gotPermissionsResult(int requestCode, String[] permissions, int[] grantResults) {
+        setGrantPermissionVisibility(false);
+    }
+}

--- a/app/src/main/java/org/andstatus/todoagenda/task/AbstractTaskProvider.java
+++ b/app/src/main/java/org/andstatus/todoagenda/task/AbstractTaskProvider.java
@@ -1,0 +1,47 @@
+package org.andstatus.todoagenda.task;
+
+import android.app.Activity;
+import android.content.Context;
+
+import org.andstatus.todoagenda.DateUtil;
+import org.andstatus.todoagenda.EventProvider;
+import org.joda.time.DateTime;
+
+import java.util.List;
+
+public abstract class AbstractTaskProvider extends EventProvider {
+
+    protected DateTime now;
+
+    public AbstractTaskProvider(Context context, int widgetId) {
+        super(context, widgetId);
+    }
+
+    @Override
+    protected void initialiseParameters() {
+        super.initialiseParameters();
+        // Move endOfTime to end of day to include all tasks in the last day of range
+        mEndOfTimeRange = mEndOfTimeRange.millisOfDay().withMaximumValue();
+
+        now = DateUtil.now(zone);
+    }
+
+    public abstract List<TaskEvent> getTasks();
+
+    protected DateTime getDueDate(Long dueMillis) {
+        if (dueMillis == null) {
+            return now.withTimeAtStartOfDay();
+        } else {
+            DateTime dueDate = new DateTime(dueMillis, zone);
+            if (dueDate.isBefore(now)) {
+                dueDate = now;
+            }
+
+            return dueDate.withTimeAtStartOfDay();
+        }
+    }
+
+    public abstract boolean hasPermission();
+
+    public abstract void requestPermission(Activity activity);
+}

--- a/app/src/main/java/org/andstatus/todoagenda/task/EmptyTaskProvider.java
+++ b/app/src/main/java/org/andstatus/todoagenda/task/EmptyTaskProvider.java
@@ -1,0 +1,29 @@
+package org.andstatus.todoagenda.task;
+
+import android.app.Activity;
+import android.content.Context;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class EmptyTaskProvider extends AbstractTaskProvider {
+
+    public EmptyTaskProvider(Context context, int widgetId) {
+        super(context, widgetId);
+    }
+
+    @Override
+    public List<TaskEvent> getTasks() {
+        return new ArrayList<>();
+    }
+
+    @Override
+    public boolean hasPermission() {
+        return true;
+    }
+
+    @Override
+    public void requestPermission(Activity activity) {
+        // No action necessary
+    }
+}

--- a/app/src/main/java/org/andstatus/todoagenda/task/TaskEvent.java
+++ b/app/src/main/java/org/andstatus/todoagenda/task/TaskEvent.java
@@ -1,0 +1,36 @@
+package org.andstatus.todoagenda.task;
+
+import android.content.Intent;
+import org.joda.time.DateTime;
+
+public abstract class TaskEvent {
+    private long id;
+    private String title;
+    private DateTime startDate;
+
+    public long getId() {
+        return id;
+    }
+
+    public void setId(long id) {
+        this.id = id;
+    }
+
+    public String getTitle() {
+        return title;
+    }
+
+    public void setTitle(String title) {
+        this.title = title;
+    }
+
+    public DateTime getStartDate() {
+        return startDate;
+    }
+
+    public void setStartDate(DateTime startDate) {
+        this.startDate = startDate;
+    }
+
+    public abstract Intent createOpenCalendarEventIntent();
+}

--- a/app/src/main/java/org/andstatus/todoagenda/task/TaskProvider.java
+++ b/app/src/main/java/org/andstatus/todoagenda/task/TaskProvider.java
@@ -1,0 +1,48 @@
+package org.andstatus.todoagenda.task;
+
+import android.app.Activity;
+import android.content.Context;
+
+import org.andstatus.todoagenda.EventProvider;
+import org.andstatus.todoagenda.prefs.ApplicationPreferences;
+import org.andstatus.todoagenda.task.dmfs.DmfsOpenTasksProvider;
+import org.andstatus.todoagenda.task.samsung.SamsungTasksProvider;
+
+import java.util.List;
+
+public class TaskProvider extends EventProvider {
+
+    private static final String PROVIDER_DMFS = "DMFS_OPEN_TASKS";
+    private static final String PROVIDER_SAMSUNG = "SAMSUNG";
+
+    public TaskProvider(Context context, int widgetId) {
+        super(context, widgetId);
+    }
+
+    public List<TaskEvent> getEvents() {
+        AbstractTaskProvider provider = getProvider();
+        return provider.getTasks();
+    }
+
+    public boolean hasPermission() {
+        AbstractTaskProvider provider = getProvider();
+        return provider.hasPermission();
+    }
+
+    public void requestPermission(Activity activity) {
+        AbstractTaskProvider provider = getProvider();
+        provider.requestPermission(activity);
+    }
+
+    private AbstractTaskProvider getProvider() {
+        String taskSource = ApplicationPreferences.getTaskSource(context);
+        if (PROVIDER_DMFS.equals(taskSource)) {
+            return new DmfsOpenTasksProvider(context, widgetId);
+        }
+        if (PROVIDER_SAMSUNG.equals(taskSource)) {
+            return new SamsungTasksProvider(context, widgetId);
+        }
+
+        return new EmptyTaskProvider(context, widgetId);
+    }
+}

--- a/app/src/main/java/org/andstatus/todoagenda/task/TaskProvider.java
+++ b/app/src/main/java/org/andstatus/todoagenda/task/TaskProvider.java
@@ -4,7 +4,6 @@ import android.app.Activity;
 import android.content.Context;
 
 import org.andstatus.todoagenda.EventProvider;
-import org.andstatus.todoagenda.prefs.ApplicationPreferences;
 import org.andstatus.todoagenda.task.dmfs.DmfsOpenTasksProvider;
 import org.andstatus.todoagenda.task.samsung.SamsungTasksProvider;
 
@@ -35,7 +34,7 @@ public class TaskProvider extends EventProvider {
     }
 
     private AbstractTaskProvider getProvider() {
-        String taskSource = ApplicationPreferences.getTaskSource(context);
+        String taskSource = getSettings().getTaskSource();
         if (PROVIDER_DMFS.equals(taskSource)) {
             return new DmfsOpenTasksProvider(context, widgetId);
         }

--- a/app/src/main/java/org/andstatus/todoagenda/task/TaskVisualizer.java
+++ b/app/src/main/java/org/andstatus/todoagenda/task/TaskVisualizer.java
@@ -1,0 +1,72 @@
+package org.andstatus.todoagenda.task;
+
+import android.content.Context;
+import android.widget.RemoteViews;
+import org.andstatus.todoagenda.IEventVisualizer;
+import org.andstatus.todoagenda.R;
+import org.andstatus.todoagenda.prefs.InstanceSettings;
+import org.andstatus.todoagenda.widget.TaskEntry;
+import org.andstatus.todoagenda.widget.WidgetEntry;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.andstatus.todoagenda.RemoteViewsUtil.setMultiline;
+import static org.andstatus.todoagenda.RemoteViewsUtil.setTextColorFromAttr;
+import static org.andstatus.todoagenda.RemoteViewsUtil.setTextSize;
+
+public class TaskVisualizer implements IEventVisualizer<TaskEntry> {
+    private final Context context;
+    private final int widgetId;
+    private final TaskProvider taskProvider;
+
+    public TaskVisualizer(Context context, int widgetId) {
+        this.context = context;
+        this.widgetId = widgetId;
+        this.taskProvider = new TaskProvider(context, widgetId);
+    }
+
+    @Override
+    public RemoteViews getRemoteView(WidgetEntry eventEntry) {
+        TaskEntry entry = (TaskEntry) eventEntry;
+        RemoteViews rv = new RemoteViews(context.getPackageName(), R.layout.task_entry);
+        setTitle(entry, rv);
+        rv.setOnClickFillInIntent(R.id.task_entry, entry.getEvent().createOpenCalendarEventIntent());
+        return rv;
+    }
+
+    private void setTitle(TaskEntry entry, RemoteViews rv) {
+        rv.setTextViewText(R.id.task_entry_title, entry.getTitle());
+        setTextSize(getSettings(), rv, R.id.task_entry_icon, R.dimen.event_entry_title);
+        setTextSize(getSettings(), rv, R.id.task_entry_title, R.dimen.event_entry_title);
+        setTextColorFromAttr(getSettings().getEntryThemeContext(), rv, R.id.task_entry_title, R.attr.eventEntryTitle);
+        setMultiline(rv, R.id.task_entry_title, getSettings().isTitleMultiline());
+    }
+
+    public InstanceSettings getSettings() {
+        return InstanceSettings.fromId(context, widgetId);
+    }
+
+    @Override
+    public int getViewTypeCount() {
+        return 1;
+    }
+
+    @Override
+    public List<TaskEntry> getEventEntries() {
+        return createEntryList(taskProvider.getEvents());
+    }
+
+    private List<TaskEntry> createEntryList(List<TaskEvent> events) {
+        List<TaskEntry> entries = new ArrayList<>();
+        for (TaskEvent event : events) {
+            entries.add(TaskEntry.fromEvent(event));
+        }
+        return entries;
+    }
+
+    @Override
+    public Class<? extends TaskEntry> getSupportedEventEntryType() {
+        return TaskEntry.class;
+    }
+}

--- a/app/src/main/java/org/andstatus/todoagenda/task/dmfs/DmfsOpenTasksContract.java
+++ b/app/src/main/java/org/andstatus/todoagenda/task/dmfs/DmfsOpenTasksContract.java
@@ -1,0 +1,15 @@
+package org.andstatus.todoagenda.task.dmfs;
+
+import android.net.Uri;
+
+public class DmfsOpenTasksContract {
+    public static final Uri PROVIDER_URI = Uri.parse("content://org.dmfs.tasks/tasks");
+
+    public static final String COLUMN_ID = "_id";
+    public static final String COLUMN_TITLE = "title";
+    public static final String COLUMN_DUE_DATE = "due";
+    public static final String COLUMN_STATUS = "status";
+    public static final int STATUS_COMPLETED = 2;
+
+    public static final String PERMISSION = "org.dmfs.permission.READ_TASKS";
+}

--- a/app/src/main/java/org/andstatus/todoagenda/task/dmfs/DmfsOpenTasksEvent.java
+++ b/app/src/main/java/org/andstatus/todoagenda/task/dmfs/DmfsOpenTasksEvent.java
@@ -1,0 +1,15 @@
+package org.andstatus.todoagenda.task.dmfs;
+
+import android.content.ContentUris;
+import android.content.Intent;
+import org.andstatus.todoagenda.CalendarIntentUtil;
+import org.andstatus.todoagenda.task.TaskEvent;
+
+public class DmfsOpenTasksEvent extends TaskEvent {
+    @Override
+    public Intent createOpenCalendarEventIntent() {
+        Intent intent = CalendarIntentUtil.createCalendarIntent();
+        intent.setData(ContentUris.withAppendedId(DmfsOpenTasksContract.PROVIDER_URI, getId()));
+        return intent;
+    }
+}

--- a/app/src/main/java/org/andstatus/todoagenda/task/dmfs/DmfsOpenTasksProvider.java
+++ b/app/src/main/java/org/andstatus/todoagenda/task/dmfs/DmfsOpenTasksProvider.java
@@ -1,0 +1,110 @@
+package org.andstatus.todoagenda.task.dmfs;
+
+import android.app.Activity;
+import android.content.Context;
+import android.content.pm.PackageManager;
+import android.database.Cursor;
+import android.net.Uri;
+import android.support.v4.app.ActivityCompat;
+import android.support.v4.content.ContextCompat;
+
+import org.andstatus.todoagenda.calendar.CalendarQueryResult;
+import org.andstatus.todoagenda.calendar.CalendarQueryResultsStorage;
+import org.andstatus.todoagenda.task.AbstractTaskProvider;
+import org.andstatus.todoagenda.task.TaskEvent;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class DmfsOpenTasksProvider extends AbstractTaskProvider {
+
+    public DmfsOpenTasksProvider(Context context, int widgetId) {
+        super(context, widgetId);
+    }
+
+    @Override
+    public List<TaskEvent> getTasks() {
+        if (!hasPermission()) {
+            return new ArrayList<>();
+        }
+
+        initialiseParameters();
+
+        return queryTasks();
+    }
+
+    private List<TaskEvent> queryTasks() {
+        Uri uri = DmfsOpenTasksContract.PROVIDER_URI;
+        String[] projection = {
+                DmfsOpenTasksContract.COLUMN_ID,
+                DmfsOpenTasksContract.COLUMN_TITLE,
+                DmfsOpenTasksContract.COLUMN_DUE_DATE
+        };
+        String where = getWhereClause();
+
+        CalendarQueryResult result = new CalendarQueryResult(getSettings(), uri, projection, where, null, null);
+
+        Cursor cursor = context.getContentResolver().query(uri, projection, where, null, null);
+        if (cursor == null) {
+            return new ArrayList<>();
+        }
+
+        List<TaskEvent> tasks = new ArrayList<>();
+        try {
+            while (cursor.moveToNext()) {
+                if (CalendarQueryResultsStorage.getNeedToStoreResults()) {
+                    result.addRow(cursor);
+                }
+
+                TaskEvent task = createTask(cursor);
+                if (!mKeywordsFilter.matched(task.getTitle())) {
+                    tasks.add(task);
+                }
+            }
+        } finally {
+            cursor.close();
+        }
+
+        CalendarQueryResultsStorage.store(result);
+
+        return tasks;
+    }
+
+    private String getWhereClause() {
+        StringBuilder whereBuilder = new StringBuilder();
+        whereBuilder.append(DmfsOpenTasksContract.COLUMN_STATUS).append(NOT_EQUALS).append(DmfsOpenTasksContract.STATUS_COMPLETED);
+
+        whereBuilder.append(AND_BRACKET)
+                .append(DmfsOpenTasksContract.COLUMN_DUE_DATE).append(LTE).append(mEndOfTimeRange.getMillis())
+                .append(OR)
+                .append(DmfsOpenTasksContract.COLUMN_DUE_DATE).append(IS_NULL)
+                .append(CLOSING_BRACKET);
+
+        return whereBuilder.toString();
+    }
+
+    private TaskEvent createTask(Cursor cursor) {
+        TaskEvent task = new DmfsOpenTasksEvent();
+        task.setId(cursor.getLong(cursor.getColumnIndex(DmfsOpenTasksContract.COLUMN_ID)));
+        task.setTitle(cursor.getString(cursor.getColumnIndex(DmfsOpenTasksContract.COLUMN_TITLE)));
+
+        int dueDateIdx = cursor.getColumnIndex(DmfsOpenTasksContract.COLUMN_DUE_DATE);
+        Long dueMillis = null;
+        if (!cursor.isNull(dueDateIdx)) {
+            dueMillis = cursor.getLong(dueDateIdx);
+        }
+        task.setStartDate(getDueDate(dueMillis));
+
+        return task;
+    }
+
+    @Override
+    public boolean hasPermission() {
+        return ContextCompat.checkSelfPermission(context, DmfsOpenTasksContract.PERMISSION) == PackageManager.PERMISSION_GRANTED;
+    }
+
+    @Override
+    public void requestPermission(Activity activity) {
+        ActivityCompat.requestPermissions(activity, new String[]{DmfsOpenTasksContract.PERMISSION}, 1);
+    }
+}

--- a/app/src/main/java/org/andstatus/todoagenda/task/samsung/SamsungTaskEvent.java
+++ b/app/src/main/java/org/andstatus/todoagenda/task/samsung/SamsungTaskEvent.java
@@ -1,0 +1,23 @@
+package org.andstatus.todoagenda.task.samsung;
+
+import android.content.ContentUris;
+import android.content.Intent;
+import android.provider.CalendarContract;
+
+import org.andstatus.todoagenda.CalendarIntentUtil;
+import org.andstatus.todoagenda.task.TaskEvent;
+
+public class SamsungTaskEvent extends TaskEvent {
+
+    @Override
+    public Intent createOpenCalendarEventIntent() {
+        Intent intent = CalendarIntentUtil.createCalendarIntent();
+        intent.setData(ContentUris.withAppendedId(CalendarContract.Events.CONTENT_URI, getId()));
+        intent.putExtra(SamsungTasksContract.INTENT_EXTRA_TASK, true);
+        intent.putExtra(SamsungTasksContract.INTENT_EXTRA_SELECTED, getId());
+        intent.putExtra(SamsungTasksContract.INTENT_EXTRA_ACTION_VIEW_FOCUS, 0);
+        intent.putExtra(SamsungTasksContract.INTENT_EXTRA_DETAIL_MODE, true);
+        intent.putExtra(SamsungTasksContract.INTENT_EXTRA_LAUNCH_FROM_WIDGET, true);
+        return intent;
+    }
+}

--- a/app/src/main/java/org/andstatus/todoagenda/task/samsung/SamsungTasksContract.java
+++ b/app/src/main/java/org/andstatus/todoagenda/task/samsung/SamsungTasksContract.java
@@ -1,0 +1,20 @@
+package org.andstatus.todoagenda.task.samsung;
+
+import android.net.Uri;
+
+public class SamsungTasksContract {
+
+    public static final Uri PROVIDER_URI = Uri.parse("content://com.android.calendar/syncTasks");
+
+    public static final String COLUMN_ID = "_id";
+    public static final String COLUMN_TITLE = "subject";
+    public static final String COLUMN_DUE_DATE = "utc_due_date";
+    public static final String COLUMN_COMPLETE = "complete";
+    public static final String COLUMN_DELETED = "deleted";
+
+    public static final String INTENT_EXTRA_TASK = "task";
+    public static final String INTENT_EXTRA_SELECTED = "selected";
+    public static final String INTENT_EXTRA_ACTION_VIEW_FOCUS = "action_view_focus";
+    public static final String INTENT_EXTRA_DETAIL_MODE = "DetailMode";
+    public static final String INTENT_EXTRA_LAUNCH_FROM_WIDGET = "launch_from_widget";
+}

--- a/app/src/main/java/org/andstatus/todoagenda/task/samsung/SamsungTasksProvider.java
+++ b/app/src/main/java/org/andstatus/todoagenda/task/samsung/SamsungTasksProvider.java
@@ -1,0 +1,103 @@
+package org.andstatus.todoagenda.task.samsung;
+
+import android.app.Activity;
+import android.content.Context;
+import android.database.Cursor;
+import android.net.Uri;
+
+import org.andstatus.todoagenda.calendar.CalendarQueryResult;
+import org.andstatus.todoagenda.calendar.CalendarQueryResultsStorage;
+import org.andstatus.todoagenda.task.AbstractTaskProvider;
+import org.andstatus.todoagenda.task.TaskEvent;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class SamsungTasksProvider extends AbstractTaskProvider {
+
+    public SamsungTasksProvider(Context context, int widgetId) {
+        super(context, widgetId);
+    }
+
+    @Override
+    public List<TaskEvent> getTasks() {
+        initialiseParameters();
+        return queryTasks();
+    }
+
+    private List<TaskEvent> queryTasks() {
+        Uri uri = SamsungTasksContract.PROVIDER_URI;
+        String[] projection = {
+                SamsungTasksContract.COLUMN_ID,
+                SamsungTasksContract.COLUMN_TITLE,
+                SamsungTasksContract.COLUMN_DUE_DATE
+        };
+        String where = getWhereClause();
+
+        CalendarQueryResult result = new CalendarQueryResult(getSettings(), uri, projection, where, null, null);
+
+        Cursor cursor = context.getContentResolver().query(uri, projection, where, null, null);
+        if (cursor == null) {
+            return new ArrayList<>();
+        }
+
+        List<TaskEvent> tasks = new ArrayList<>();
+        try {
+            while (cursor.moveToNext()) {
+                if (CalendarQueryResultsStorage.getNeedToStoreResults()) {
+                    result.addRow(cursor);
+                }
+
+                TaskEvent task = createTask(cursor);
+                if (!mKeywordsFilter.matched(task.getTitle())) {
+                    tasks.add(task);
+                }
+            }
+        } finally {
+            cursor.close();
+        }
+
+        CalendarQueryResultsStorage.store(result);
+
+        return tasks;
+    }
+
+    private String getWhereClause() {
+        StringBuilder whereBuilder = new StringBuilder();
+        whereBuilder.append(SamsungTasksContract.COLUMN_COMPLETE).append(EQUALS).append("0");
+        whereBuilder.append(AND).append(SamsungTasksContract.COLUMN_DELETED).append(EQUALS).append("0");
+
+        whereBuilder.append(AND_BRACKET)
+                .append(SamsungTasksContract.COLUMN_DUE_DATE).append(LTE).append(mEndOfTimeRange.getMillis())
+                .append(OR)
+                .append(SamsungTasksContract.COLUMN_DUE_DATE).append(IS_NULL)
+                .append(CLOSING_BRACKET);
+
+        return whereBuilder.toString();
+    }
+
+    private TaskEvent createTask(Cursor cursor) {
+        TaskEvent task = new SamsungTaskEvent();
+        task.setId(cursor.getLong(cursor.getColumnIndex(SamsungTasksContract.COLUMN_ID)));
+        task.setTitle(cursor.getString(cursor.getColumnIndex(SamsungTasksContract.COLUMN_TITLE)));
+
+        int dueDateIdx = cursor.getColumnIndex(SamsungTasksContract.COLUMN_DUE_DATE);
+        Long dueMillis = null;
+        if (!cursor.isNull(dueDateIdx)) {
+            dueMillis = cursor.getLong(dueDateIdx);
+        }
+        task.setStartDate(getDueDate(dueMillis));
+
+        return task;
+    }
+
+    @Override
+    public boolean hasPermission() {
+        return true;
+    }
+
+    @Override
+    public void requestPermission(Activity activity) {
+        // Requires just android.permission.READ_CALENDAR, which is expected to be granted already
+    }
+}

--- a/app/src/main/java/org/andstatus/todoagenda/widget/CalendarEntry.java
+++ b/app/src/main/java/org/andstatus/todoagenda/widget/CalendarEntry.java
@@ -162,6 +162,11 @@ public class CalendarEntry extends WidgetEntry {
     }
 
     @Override
+    public int getPriority() {
+        return 30;
+    }
+
+    @Override
     public String toString() {
         return "CalendarEntry ["
                 + "startDate=" + getStartDate()

--- a/app/src/main/java/org/andstatus/todoagenda/widget/DayHeader.java
+++ b/app/src/main/java/org/andstatus/todoagenda/widget/DayHeader.java
@@ -8,4 +8,8 @@ public class DayHeader extends WidgetEntry {
         setStartDate(date.withTimeAtStartOfDay());
     }
 
+    @Override
+    public int getPriority() {
+        return 10;
+    }
 }

--- a/app/src/main/java/org/andstatus/todoagenda/widget/TaskEntry.java
+++ b/app/src/main/java/org/andstatus/todoagenda/widget/TaskEntry.java
@@ -1,0 +1,27 @@
+package org.andstatus.todoagenda.widget;
+
+import org.andstatus.todoagenda.task.TaskEvent;
+
+public class TaskEntry extends WidgetEntry {
+    private TaskEvent event;
+
+    public static TaskEntry fromEvent(TaskEvent event) {
+        TaskEntry entry = new TaskEntry();
+        entry.event = event;
+        entry.setStartDate(event.getStartDate());
+        return entry;
+    }
+
+    public String getTitle() {
+        return event.getTitle();
+    }
+
+    public TaskEvent getEvent() {
+        return event;
+    }
+
+    @Override
+    public int getPriority() {
+        return 20;
+    }
+}

--- a/app/src/main/java/org/andstatus/todoagenda/widget/WidgetEntry.java
+++ b/app/src/main/java/org/andstatus/todoagenda/widget/WidgetEntry.java
@@ -1,11 +1,10 @@
 package org.andstatus.todoagenda.widget;
 
 import org.andstatus.todoagenda.DateUtil;
-
 import org.joda.time.DateTime;
 import org.joda.time.Days;
 
-public class WidgetEntry implements Comparable<WidgetEntry> {
+public abstract class WidgetEntry implements Comparable<WidgetEntry> {
 
     private DateTime startDate;
 
@@ -20,6 +19,8 @@ public class WidgetEntry implements Comparable<WidgetEntry> {
     public DateTime getStartDay() {
         return getStartDate().withTimeAtStartOfDay();
     }
+
+    public abstract int getPriority();
 
     @Override
     public String toString() {
@@ -38,6 +39,6 @@ public class WidgetEntry implements Comparable<WidgetEntry> {
         } else if (getStartDate().isBefore(otherEvent.getStartDate())) {
             return -1;
         }
-        return 0;
+        return Integer.signum(getPriority() - otherEvent.getPriority());
     }
 }

--- a/app/src/main/res/layout/task_entry.xml
+++ b/app/src/main/res/layout/task_entry.xml
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+              xmlns:tools="http://schemas.android.com/tools"
+              android:id="@+id/task_entry"
+              android:layout_width="match_parent"
+              android:layout_height="wrap_content"
+              android:paddingLeft="@dimen/calender_padding"
+              android:paddingRight="@dimen/calender_padding"
+              android:paddingBottom="@dimen/entry_bottom_padding">
+
+    <TextView
+        android:id="@+id/task_entry_icon"
+        style="@style/TaskEntryIcon"
+        android:layout_width="12dp"
+        android:layout_height="wrap_content"
+        android:gravity="center_vertical|center_horizontal"
+        android:text="@string/task_icon"
+        tools:ignore="SelectableText" />
+
+    <TextView
+        android:id="@+id/task_entry_title"
+        style="@style/EventEntryTitle"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:gravity="center_vertical"
+        tools:text="Task Entry Title. It may be long and not fit in one line"
+        tools:ignore="SelectableText"/>
+
+</LinearLayout>

--- a/app/src/main/res/values/arrays.xml
+++ b/app/src/main/res/values/arrays.xml
@@ -93,4 +93,14 @@
         <item>DEFAULT</item>
         <item>ONE_LINE</item>
     </string-array>
+    <string-array name="pref_task_source_entries">
+        <item>@string/task_source_none</item>
+        <item>@string/task_source_opentasks</item>
+        <item>@string/task_source_samsung</item>
+    </string-array>
+    <string-array name="pref_task_source_values" tools:ignore="MissingTranslation">
+        <item>NONE</item>
+        <item>DMFS_OPEN_TASKS</item>
+        <item>SAMSUNG</item>
+    </string-array>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -20,6 +20,7 @@
     <string name="select_a_widget_to_configure">Select a widget to configure</string>
     <string name="close">Close</string>
     <string name="go_to_home_screen">Go to home screen</string>
+    <string name="task_icon" translatable="false">✔</string>
 
     <!-- Descriptions for app markets -->
     <string name="app_description_80_chars_max">Widgets displaying lists of upcoming (and past…) events from selected calendars</string>
@@ -135,6 +136,17 @@
     <string name="ended_yesterday">Ended yesterday</string>
     <string name="pref_hide_based_on_keywords_title">Hide based on keywords in a title</string>
     <string name="show_only_closest_instance_of_recurring_event">Show only the closest instance of a recurring event</string>
+
+    <!-- Preference header: Tasks -->
+    <string name="task_prefs">Tasks</string>
+    <string name="task_prefs_desc">Configure display of tasks/TODOs</string>
+    <string name="task_source_pref_title">Task events source</string>
+    <string name="task_source_pref_desc">Select the source from which to get task events</string>
+    <string name="task_source_none">Don\'t display tasks</string>
+    <string name="task_source_opentasks">OpenTasks (by dmfs GmbH)</string>
+    <string name="task_source_samsung">Samsung Calendar</string>
+    <string name="grant_task_permission_title">Grant permission to fetch tasks</string>
+    <string name="grant_task_permission_desc">You need to grant permission for tasks to be displayed</string>
 
     <!-- Preference header: Feedback -->
     <string name="feedback_prefs">Feedback</string>

--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -47,4 +47,9 @@
         <item name="android:layout_marginRight">8dp</item>
     </style>
 
+    <style name="TaskEntryIcon" parent="android:Widget.Holo.TextView">
+        <item name="android:textColor">@android:color/holo_green_dark</item>
+        <item name="android:layout_marginRight">4dp</item>
+    </style>
+
 </resources>

--- a/app/src/main/res/xml/preferences_header.xml
+++ b/app/src/main/res/xml/preferences_header.xml
@@ -17,6 +17,10 @@
         android:summary="@string/calendars_prefs_desc"
         android:title="@string/calendars_prefs" />
     <header
+        android:fragment="org.andstatus.todoagenda.prefs.TaskPreferencesFragment"
+        android:summary="@string/task_prefs_desc"
+        android:title="@string/task_prefs" />
+    <header
         android:fragment="org.andstatus.todoagenda.prefs.FeedbackPreferencesFragment"
         android:summary="@string/feedback_prefs_desc"
         android:title="@string/feedback_prefs" />

--- a/app/src/main/res/xml/preferences_task.xml
+++ b/app/src/main/res/xml/preferences_task.xml
@@ -1,0 +1,14 @@
+<PreferenceScreen xmlns:android="http://schemas.android.com/apk/res/android">
+    <ListPreference
+        android:defaultValue="NONE"
+        android:entries="@array/pref_task_source_entries"
+        android:entryValues="@array/pref_task_source_values"
+        android:key="taskSource"
+        android:title="@string/task_source_pref_title"
+        android:summary="@string/task_source_pref_desc" />
+    <Preference
+        android:key="grantTaskPermission"
+        android:title="@string/grant_task_permission_title"
+        android:summary="@string/grant_task_permission_desc"
+        android:persistent="false" />
+</PreferenceScreen>


### PR DESCRIPTION
Fixes #308.

This is still somewhat basic, but functional, fetching tasks from Samsung Calendar or Dmfs OpenTasks, and it should be relatively straightforward to add support for other applications (as long as one knows how to fetch data from its content provider and set up an Intent to open the task in that application).