### PR TITLE
Support for selecting task lists to display

### DIFF
--- a/app/src/main/java/org/andstatus/todoagenda/EventProvider.java
+++ b/app/src/main/java/org/andstatus/todoagenda/EventProvider.java
@@ -8,6 +8,8 @@ import org.andstatus.todoagenda.prefs.InstanceSettings;
 import org.joda.time.DateTime;
 import org.joda.time.DateTimeZone;
 
+import static android.graphics.Color.*;
+
 public abstract class EventProvider {
 
     protected static final String AND_BRACKET = " AND (";
@@ -51,5 +53,9 @@ public abstract class EventProvider {
     @NonNull
     protected InstanceSettings getSettings() {
         return InstanceSettings.fromId(context, widgetId);
+    }
+
+    protected int getAsOpaque(int color) {
+        return argb(255, red(color), green(color), blue(color));
     }
 }

--- a/app/src/main/java/org/andstatus/todoagenda/calendar/CalendarEventProvider.java
+++ b/app/src/main/java/org/andstatus/todoagenda/calendar/CalendarEventProvider.java
@@ -20,11 +20,6 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Set;
 
-import static android.graphics.Color.argb;
-import static android.graphics.Color.blue;
-import static android.graphics.Color.green;
-import static android.graphics.Color.red;
-
 public class CalendarEventProvider extends EventProvider {
 
     public static final String EVENT_SORT_ORDER = "startDay ASC, allDay DESC, begin ASC ";
@@ -225,9 +220,5 @@ public class CalendarEventProvider extends EventProvider {
             }
             return cursor.getInt(cursor.getColumnIndex(Instances.CALENDAR_COLOR));
         }
-    }
-
-    private int getAsOpaque(int color) {
-        return argb(255, red(color), green(color), blue(color));
     }
 }

--- a/app/src/main/java/org/andstatus/todoagenda/prefs/AbstractEventSourcesPreferencesFragment.java
+++ b/app/src/main/java/org/andstatus/todoagenda/prefs/AbstractEventSourcesPreferencesFragment.java
@@ -1,0 +1,84 @@
+package org.andstatus.todoagenda.prefs;
+
+import android.graphics.LightingColorFilter;
+import android.graphics.drawable.Drawable;
+import android.os.Bundle;
+import android.preference.CheckBoxPreference;
+import android.preference.Preference;
+import android.preference.PreferenceFragment;
+import android.preference.PreferenceScreen;
+
+import org.andstatus.todoagenda.EventAppWidgetProvider;
+import org.andstatus.todoagenda.R;
+
+import java.util.Collection;
+import java.util.HashSet;
+import java.util.Set;
+
+abstract class AbstractEventSourcesPreferencesFragment extends PreferenceFragment {
+
+    private static final String SOURCE_ID = "sourceId";
+
+    private Set<String> initialActiveSources;
+
+    @Override
+    public void onCreate(Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+        addPreferencesFromResource(R.xml.preferences_calendars);
+        initialActiveSources = fetchInitialActiveSources();
+        populatePreferenceScreen(initialActiveSources);
+    }
+
+    protected abstract Set<String> fetchInitialActiveSources();
+
+    private void populatePreferenceScreen(Set<String> activeCalendars) {
+        Collection<EventSource> availableSources = fetchAvailableSources();
+        for (EventSource source : availableSources) {
+            CheckBoxPreference checkboxPref = new CheckBoxPreference(getActivity());
+            checkboxPref.setTitle(source.getTitle());
+            checkboxPref.setSummary(source.getSummary());
+            checkboxPref.setIcon(createDrawable(source.getColor()));
+            int sourceId = source.getId();
+            checkboxPref.getExtras().putInt(SOURCE_ID, sourceId);
+            checkboxPref.setChecked(activeCalendars.isEmpty()
+                    || activeCalendars.contains(String.valueOf(sourceId)));
+            getPreferenceScreen().addPreference(checkboxPref);
+        }
+    }
+
+    protected abstract Collection<EventSource> fetchAvailableSources();
+
+    @Override
+    public void onPause() {
+        super.onPause();
+        Set<String> selectedSources = getSelectedSources();
+        if (!selectedSources.equals(initialActiveSources)) {
+            storeSelectedSources(selectedSources);
+            EventAppWidgetProvider.updateEventList(getActivity());
+        }
+    }
+
+    protected abstract void storeSelectedSources(Set<String> selectedSources);
+
+    private Set<String> getSelectedSources() {
+        PreferenceScreen preferenceScreen = getPreferenceScreen();
+        int prefCount = preferenceScreen.getPreferenceCount();
+        Set<String> prefValues = new HashSet<>();
+        for (int i = 0; i < prefCount; i++) {
+            Preference pref = preferenceScreen.getPreference(i);
+            if (pref instanceof CheckBoxPreference) {
+                CheckBoxPreference checkPref = (CheckBoxPreference) pref;
+                if (checkPref.isChecked()) {
+                    prefValues.add(String.valueOf(checkPref.getExtras().getInt(SOURCE_ID)));
+                }
+            }
+        }
+        return prefValues;
+    }
+
+    private Drawable createDrawable(int color) {
+        Drawable drawable = getResources().getDrawable(R.drawable.prefs_calendar_entry);
+        drawable.setColorFilter(new LightingColorFilter(0x0, color));
+        return drawable;
+    }
+}

--- a/app/src/main/java/org/andstatus/todoagenda/prefs/ApplicationPreferences.java
+++ b/app/src/main/java/org/andstatus/todoagenda/prefs/ApplicationPreferences.java
@@ -8,9 +8,10 @@ import android.text.TextUtils;
 import org.andstatus.todoagenda.Alignment;
 import org.andstatus.todoagenda.EndedSomeTimeAgo;
 import org.andstatus.todoagenda.Theme;
+import org.andstatus.todoagenda.task.TaskProvider;
 import org.andstatus.todoagenda.widget.EventEntryLayout;
 
-import java.util.HashSet;
+import java.util.Collections;
 import java.util.Set;
 
 public class ApplicationPreferences {
@@ -59,7 +60,8 @@ public class ApplicationPreferences {
     static final String PREF_SHOW_ONLY_CLOSEST_INSTANCE_OF_RECURRING_EVENT =
             "showOnlyClosestInstanceOfRecurringEvent";
     static final String PREF_TASK_SOURCE = "taskSource";
-    static final String PREF_TASK_SOURCE_DEFAULT = "NONE";
+    static final String PREF_TASK_SOURCE_DEFAULT = TaskProvider.PROVIDER_NONE;
+    static final String PREF_ACTIVE_TASK_LISTS = "activeTaskLists";
     static final String PREF_WIDGET_INSTANCE_NAME = "widgetInstanceName";
 
     private static volatile String lockedTimeZoneId = null;
@@ -98,6 +100,8 @@ public class ApplicationPreferences {
         setInt(context, PREF_BACKGROUND_COLOR, settings.getBackgroundColor());
         setString(context, PREF_TEXT_SIZE_SCALE, settings.getTextSizeScale());
         setString(context, PREF_DAY_HEADER_ALIGNMENT, settings.getDayHeaderAlignment());
+        setString(context, PREF_TASK_SOURCE, settings.getTaskSource());
+        setActiveTaskLists(context, settings.getActiveTaskLists());
     }
 
     public static void save(Context context, int wigdetId) {
@@ -122,7 +126,7 @@ public class ApplicationPreferences {
         Set<String> activeCalendars = PreferenceManager.getDefaultSharedPreferences(context)
                 .getStringSet(PREF_ACTIVE_CALENDARS, null);
         if (activeCalendars == null) {
-            activeCalendars = new HashSet<>();
+            activeCalendars = Collections.emptySet();
         }
         return activeCalendars;
     }
@@ -264,6 +268,22 @@ public class ApplicationPreferences {
 
     public static String getTaskSource(Context context) {
         return getString(context, PREF_TASK_SOURCE, PREF_DATE_FORMAT_DEFAULT);
+    }
+
+    public static Set<String> getActiveTaskLists(Context context) {
+        Set<String> activeTaskLists = PreferenceManager.getDefaultSharedPreferences(context)
+                .getStringSet(PREF_ACTIVE_TASK_LISTS, null);
+        if (activeTaskLists == null) {
+            activeTaskLists = Collections.emptySet();
+        }
+        return activeTaskLists;
+    }
+
+    public static void setActiveTaskLists(Context context, Set<String> taskLists) {
+        SharedPreferences prefs = PreferenceManager.getDefaultSharedPreferences(context);
+        SharedPreferences.Editor editor = prefs.edit();
+        editor.putStringSet(PREF_ACTIVE_TASK_LISTS, taskLists);
+        editor.apply();
     }
 
     private static void setString(Context context, String key, String value) {

--- a/app/src/main/java/org/andstatus/todoagenda/prefs/EventSource.java
+++ b/app/src/main/java/org/andstatus/todoagenda/prefs/EventSource.java
@@ -1,0 +1,32 @@
+package org.andstatus.todoagenda.prefs;
+
+public class EventSource {
+
+    private int id;
+    private String title;
+    private String summary;
+    private int color;
+
+    public EventSource(int id, String title, String summary, int color) {
+        this.id = id;
+        this.title = title;
+        this.summary = summary;
+        this.color = color;
+    }
+
+    public int getId() {
+        return id;
+    }
+
+    public String getTitle() {
+        return title;
+    }
+
+    public String getSummary() {
+        return summary;
+    }
+
+    public int getColor() {
+        return color;
+    }
+}

--- a/app/src/main/java/org/andstatus/todoagenda/prefs/InstanceSettings.java
+++ b/app/src/main/java/org/andstatus/todoagenda/prefs/InstanceSettings.java
@@ -10,13 +10,13 @@ import org.andstatus.todoagenda.DateUtil;
 import org.andstatus.todoagenda.EndedSomeTimeAgo;
 import org.andstatus.todoagenda.R;
 import org.andstatus.todoagenda.widget.EventEntryLayout;
-
 import org.joda.time.DateTimeZone;
 import org.json.JSONArray;
 import org.json.JSONException;
 import org.json.JSONObject;
 
 import java.io.IOException;
+import java.util.Collections;
 import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
@@ -43,7 +43,7 @@ public class InstanceSettings {
     private final int widgetId;
     private final String widgetInstanceName;
     private boolean justCreated = true;
-    private Set<String> activeCalendars = new HashSet<>();
+    private Set<String> activeCalendars = Collections.emptySet();
     private int eventRange = Integer.valueOf(PREF_EVENT_RANGE_DEFAULT);
     private EndedSomeTimeAgo eventsEnded = EndedSomeTimeAgo.NONE;
     private boolean fillAllDayEvents = PREF_FILL_ALL_DAY_DEFAULT;
@@ -69,6 +69,7 @@ public class InstanceSettings {
     private String textSizeScale = PREF_TEXT_SIZE_SCALE_DEFAULT;
     private String dayHeaderAlignment = PREF_DAY_HEADER_ALIGNMENT_DEFAULT;
     private String taskSource = PREF_TASK_SOURCE_DEFAULT;
+    private Set<String> activeTaskLists = Collections.emptySet();
 
     @NonNull
     public static InstanceSettings fromId(Context context, Integer widgetId) {
@@ -217,6 +218,9 @@ public class InstanceSettings {
         if (json.has(PREF_TASK_SOURCE)) {
             settings.taskSource = json.getString(PREF_TASK_SOURCE);
         }
+        if (json.has(PREF_ACTIVE_TASK_LISTS)) {
+            settings.activeTaskLists = jsonArray2StringSet(json.getJSONArray(PREF_ACTIVE_TASK_LISTS));
+        }
         return settings;
     }
 
@@ -278,6 +282,7 @@ public class InstanceSettings {
         settings.dayHeaderAlignment = ApplicationPreferences.getString(context, PREF_DAY_HEADER_ALIGNMENT,
                 PREF_DAY_HEADER_ALIGNMENT_DEFAULT);
         settings.taskSource = ApplicationPreferences.getTaskSource(context);
+        settings.activeTaskLists = ApplicationPreferences.getActiveTaskLists(context);
         return settings;
     }
 
@@ -371,6 +376,7 @@ public class InstanceSettings {
             json.put(PREF_TEXT_SIZE_SCALE, textSizeScale);
             json.put(PREF_DAY_HEADER_ALIGNMENT, dayHeaderAlignment);
             json.put(PREF_TASK_SOURCE, taskSource);
+            json.put(PREF_ACTIVE_TASK_LISTS, new JSONArray(activeTaskLists));
         } catch (JSONException e) {
             throw new RuntimeException("Saving settings to JSON", e);
         }
@@ -536,6 +542,10 @@ public class InstanceSettings {
 
     public String getTaskSource() {
         return taskSource;
+    }
+
+    public Set<String> getActiveTaskLists() {
+        return activeTaskLists;
     }
 
     public static Map<Integer, InstanceSettings> getInstances(Context context) {

--- a/app/src/main/java/org/andstatus/todoagenda/prefs/TaskListsPreferencesFragment.java
+++ b/app/src/main/java/org/andstatus/todoagenda/prefs/TaskListsPreferencesFragment.java
@@ -1,0 +1,35 @@
+package org.andstatus.todoagenda.prefs;
+
+import android.appwidget.AppWidgetManager;
+import android.content.Intent;
+import android.os.Bundle;
+
+import org.andstatus.todoagenda.task.TaskProvider;
+
+import java.util.Collection;
+import java.util.Set;
+
+public class TaskListsPreferencesFragment extends AbstractEventSourcesPreferencesFragment {
+
+    @Override
+    public void onCreate(Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+    }
+
+    @Override
+    protected Set<String> fetchInitialActiveSources() {
+        return ApplicationPreferences.getActiveTaskLists(getActivity());
+    }
+
+    @Override
+    protected Collection<EventSource> fetchAvailableSources() {
+        Intent intent = getActivity().getIntent();
+        int widgetId = intent.getIntExtra(AppWidgetManager.EXTRA_APPWIDGET_ID, 0);
+        return new TaskProvider(getActivity(), widgetId).getTaskLists(ApplicationPreferences.getTaskSource(getActivity()));
+    }
+
+    @Override
+    protected void storeSelectedSources(Set<String> selectedSources) {
+        ApplicationPreferences.setActiveTaskLists(getActivity(), selectedSources);
+    }
+}

--- a/app/src/main/java/org/andstatus/todoagenda/prefs/TaskPreferencesFragment.java
+++ b/app/src/main/java/org/andstatus/todoagenda/prefs/TaskPreferencesFragment.java
@@ -3,12 +3,18 @@ package org.andstatus.todoagenda.prefs;
 import android.content.SharedPreferences;
 import android.os.Bundle;
 import android.preference.ListPreference;
+import android.preference.Preference;
 import android.preference.PreferenceFragment;
 
 import org.andstatus.todoagenda.EventAppWidgetProvider;
 import org.andstatus.todoagenda.R;
+import org.andstatus.todoagenda.task.TaskProvider;
+
+import java.util.Collections;
 
 public class TaskPreferencesFragment extends PreferenceFragment implements SharedPreferences.OnSharedPreferenceChangeListener {
+
+    private static final String PREF_ACTIVE_TASK_LISTS_BUTTON = "activeTaskListsButton";
 
     @Override
     public void onCreate(Bundle savedInstanceState) {
@@ -36,6 +42,8 @@ public class TaskPreferencesFragment extends PreferenceFragment implements Share
         switch (key) {
             case ApplicationPreferences.PREF_TASK_SOURCE:
                 showTaskSource();
+                setTaskListState();
+                clearTasksLists();
                 break;
         }
     }
@@ -43,5 +51,14 @@ public class TaskPreferencesFragment extends PreferenceFragment implements Share
     private void showTaskSource() {
         ListPreference preference = (ListPreference) findPreference(ApplicationPreferences.PREF_TASK_SOURCE);
         preference.setSummary(preference.getEntry());
+    }
+
+    private void setTaskListState() {
+        Preference taskListButton = findPreference(PREF_ACTIVE_TASK_LISTS_BUTTON);
+        taskListButton.setEnabled(!ApplicationPreferences.getTaskSource(getActivity()).equals(TaskProvider.PROVIDER_NONE));
+    }
+
+    private void clearTasksLists() {
+        ApplicationPreferences.setActiveTaskLists(getActivity(), Collections.<String>emptySet());
     }
 }

--- a/app/src/main/java/org/andstatus/todoagenda/task/AbstractTaskProvider.java
+++ b/app/src/main/java/org/andstatus/todoagenda/task/AbstractTaskProvider.java
@@ -4,8 +4,10 @@ import android.content.Context;
 
 import org.andstatus.todoagenda.DateUtil;
 import org.andstatus.todoagenda.EventProvider;
+import org.andstatus.todoagenda.prefs.EventSource;
 import org.joda.time.DateTime;
 
+import java.util.Collection;
 import java.util.List;
 
 public abstract class AbstractTaskProvider extends EventProvider {
@@ -24,4 +26,6 @@ public abstract class AbstractTaskProvider extends EventProvider {
     }
 
     public abstract List<TaskEvent> getTasks();
+
+    public abstract Collection<EventSource> getTaskLists();
 }

--- a/app/src/main/java/org/andstatus/todoagenda/task/EmptyTaskProvider.java
+++ b/app/src/main/java/org/andstatus/todoagenda/task/EmptyTaskProvider.java
@@ -2,7 +2,10 @@ package org.andstatus.todoagenda.task;
 
 import android.content.Context;
 
+import org.andstatus.todoagenda.prefs.EventSource;
+
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.List;
 
 public class EmptyTaskProvider extends AbstractTaskProvider {
@@ -13,6 +16,11 @@ public class EmptyTaskProvider extends AbstractTaskProvider {
 
     @Override
     public List<TaskEvent> getTasks() {
+        return new ArrayList<>();
+    }
+
+    @Override
+    public Collection<EventSource> getTaskLists() {
         return new ArrayList<>();
     }
 }

--- a/app/src/main/java/org/andstatus/todoagenda/task/TaskEvent.java
+++ b/app/src/main/java/org/andstatus/todoagenda/task/TaskEvent.java
@@ -7,11 +7,13 @@ import org.joda.time.DateTime;
 import org.joda.time.DateTimeZone;
 
 public abstract class TaskEvent {
+
     private long id;
     private String title;
     private final DateTimeZone zone;
     private DateTime startDate;
     private DateTime dueDate;
+    private int color;
 
     protected TaskEvent(DateTimeZone zone) {
         this.zone = zone;
@@ -39,6 +41,14 @@ public abstract class TaskEvent {
 
     public DateTime getDueDate() {
         return dueDate;
+    }
+
+    public int getColor() {
+        return color;
+    }
+
+    public void setColor(int color) {
+        this.color = color;
     }
 
     public abstract Intent createOpenCalendarEventIntent();

--- a/app/src/main/java/org/andstatus/todoagenda/task/TaskProvider.java
+++ b/app/src/main/java/org/andstatus/todoagenda/task/TaskProvider.java
@@ -3,12 +3,16 @@ package org.andstatus.todoagenda.task;
 import android.content.Context;
 
 import org.andstatus.todoagenda.EventProvider;
+import org.andstatus.todoagenda.prefs.EventSource;
 import org.andstatus.todoagenda.task.dmfs.DmfsOpenTasksProvider;
 import org.andstatus.todoagenda.task.samsung.SamsungTasksProvider;
 
+import java.util.Collection;
 import java.util.List;
 
 public class TaskProvider extends EventProvider {
+
+    public static final String PROVIDER_NONE = "NONE";
 
     private static final String PROVIDER_DMFS = "DMFS_OPEN_TASKS";
     private static final String PROVIDER_SAMSUNG = "SAMSUNG";
@@ -22,8 +26,19 @@ public class TaskProvider extends EventProvider {
         return provider.getTasks();
     }
 
+    // This is called from the settings activity, when the task source that the user
+    // selected has not been saved to settings yet
+    public Collection<EventSource> getTaskLists(String taskSource) {
+        AbstractTaskProvider provider = getProvider(taskSource);
+        return provider.getTaskLists();
+    }
+
     private AbstractTaskProvider getProvider() {
         String taskSource = getSettings().getTaskSource();
+        return getProvider(taskSource);
+    }
+
+    private AbstractTaskProvider getProvider(String taskSource) {
         if (PROVIDER_DMFS.equals(taskSource)) {
             return new DmfsOpenTasksProvider(context, widgetId);
         }

--- a/app/src/main/java/org/andstatus/todoagenda/task/TaskVisualizer.java
+++ b/app/src/main/java/org/andstatus/todoagenda/task/TaskVisualizer.java
@@ -32,10 +32,15 @@ public class TaskVisualizer implements IEventVisualizer<TaskEntry> {
     public RemoteViews getRemoteView(WidgetEntry eventEntry) {
         TaskEntry entry = (TaskEntry) eventEntry;
         RemoteViews rv = new RemoteViews(context.getPackageName(), R.layout.task_entry);
+        setColor(entry, rv);
         setDaysToEvent(entry, rv);
         setTitle(entry, rv);
         rv.setOnClickFillInIntent(R.id.task_entry, entry.getEvent().createOpenCalendarEventIntent());
         return rv;
+    }
+
+    private void setColor(TaskEntry entry, RemoteViews rv) {
+        rv.setTextColor(R.id.task_entry_icon, entry.getEvent().getColor());
     }
 
     private void setDaysToEvent(TaskEntry entry, RemoteViews rv) {

--- a/app/src/main/java/org/andstatus/todoagenda/task/dmfs/DmfsOpenTasksContract.java
+++ b/app/src/main/java/org/andstatus/todoagenda/task/dmfs/DmfsOpenTasksContract.java
@@ -12,6 +12,7 @@ public class DmfsOpenTasksContract {
         public static final String COLUMN_TITLE = "title";
         public static final String COLUMN_DUE_DATE = "due";
         public static final String COLUMN_START_DATE = "dtstart";
+        public static final String COLUMN_COLOR = "list_color";
         public static final String COLUMN_STATUS = "status";
         public static final String COLUMN_LIST_ID = "list_id";
 

--- a/app/src/main/java/org/andstatus/todoagenda/task/dmfs/DmfsOpenTasksContract.java
+++ b/app/src/main/java/org/andstatus/todoagenda/task/dmfs/DmfsOpenTasksContract.java
@@ -3,14 +3,29 @@ package org.andstatus.todoagenda.task.dmfs;
 import android.net.Uri;
 
 public class DmfsOpenTasksContract {
-    public static final Uri PROVIDER_URI = Uri.parse("content://org.dmfs.tasks/tasks");
 
-    public static final String COLUMN_ID = "_id";
-    public static final String COLUMN_TITLE = "title";
-    public static final String COLUMN_DUE_DATE = "due";
-    public static final String COLUMN_START_DATE = "dtstart";
-    public static final String COLUMN_STATUS = "status";
-    public static final int STATUS_COMPLETED = 2;
+    public static class Tasks {
+
+        public static final Uri PROVIDER_URI = Uri.parse("content://org.dmfs.tasks/tasks");
+
+        public static final String COLUMN_ID = "_id";
+        public static final String COLUMN_TITLE = "title";
+        public static final String COLUMN_DUE_DATE = "due";
+        public static final String COLUMN_START_DATE = "dtstart";
+        public static final String COLUMN_STATUS = "status";
+
+        public static final int STATUS_COMPLETED = 2;
+    }
+
+    public static class TaskLists {
+
+        public static final Uri PROVIDER_URI = Uri.parse("content://org.dmfs.tasks/tasklists");
+
+        public static final String COLUMN_ID = "_id";
+        public static final String COLUMN_NAME = "list_name";
+        public static final String COLUMN_COLOR = "list_color";
+        public static final String COLUMN_ACCOUNT_NAME = "account_name";
+    }
 
     public static final String PERMISSION = "org.dmfs.permission.READ_TASKS";
 }

--- a/app/src/main/java/org/andstatus/todoagenda/task/dmfs/DmfsOpenTasksContract.java
+++ b/app/src/main/java/org/andstatus/todoagenda/task/dmfs/DmfsOpenTasksContract.java
@@ -13,6 +13,7 @@ public class DmfsOpenTasksContract {
         public static final String COLUMN_DUE_DATE = "due";
         public static final String COLUMN_START_DATE = "dtstart";
         public static final String COLUMN_STATUS = "status";
+        public static final String COLUMN_LIST_ID = "list_id";
 
         public static final int STATUS_COMPLETED = 2;
     }

--- a/app/src/main/java/org/andstatus/todoagenda/task/dmfs/DmfsOpenTasksEvent.java
+++ b/app/src/main/java/org/andstatus/todoagenda/task/dmfs/DmfsOpenTasksEvent.java
@@ -2,6 +2,7 @@ package org.andstatus.todoagenda.task.dmfs;
 
 import android.content.ContentUris;
 import android.content.Intent;
+
 import org.andstatus.todoagenda.CalendarIntentUtil;
 import org.andstatus.todoagenda.task.TaskEvent;
 import org.joda.time.DateTimeZone;
@@ -14,7 +15,7 @@ public class DmfsOpenTasksEvent extends TaskEvent {
     @Override
     public Intent createOpenCalendarEventIntent() {
         Intent intent = CalendarIntentUtil.createCalendarIntent();
-        intent.setData(ContentUris.withAppendedId(DmfsOpenTasksContract.PROVIDER_URI, getId()));
+        intent.setData(ContentUris.withAppendedId(DmfsOpenTasksContract.Tasks.PROVIDER_URI, getId()));
         return intent;
     }
 }

--- a/app/src/main/java/org/andstatus/todoagenda/task/dmfs/DmfsOpenTasksProvider.java
+++ b/app/src/main/java/org/andstatus/todoagenda/task/dmfs/DmfsOpenTasksProvider.java
@@ -6,10 +6,12 @@ import android.net.Uri;
 
 import org.andstatus.todoagenda.calendar.CalendarQueryResult;
 import org.andstatus.todoagenda.calendar.CalendarQueryResultsStorage;
+import org.andstatus.todoagenda.prefs.EventSource;
 import org.andstatus.todoagenda.task.AbstractTaskProvider;
 import org.andstatus.todoagenda.task.TaskEvent;
 
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.List;
 
 public class DmfsOpenTasksProvider extends AbstractTaskProvider {
@@ -26,12 +28,12 @@ public class DmfsOpenTasksProvider extends AbstractTaskProvider {
     }
 
     private List<TaskEvent> queryTasks() {
-        Uri uri = DmfsOpenTasksContract.PROVIDER_URI;
+        Uri uri = DmfsOpenTasksContract.Tasks.PROVIDER_URI;
         String[] projection = {
-                DmfsOpenTasksContract.COLUMN_ID,
-                DmfsOpenTasksContract.COLUMN_TITLE,
-                DmfsOpenTasksContract.COLUMN_DUE_DATE,
-                DmfsOpenTasksContract.COLUMN_START_DATE,
+                DmfsOpenTasksContract.Tasks.COLUMN_ID,
+                DmfsOpenTasksContract.Tasks.COLUMN_TITLE,
+                DmfsOpenTasksContract.Tasks.COLUMN_DUE_DATE,
+                DmfsOpenTasksContract.Tasks.COLUMN_START_DATE,
         };
         String where = getWhereClause();
 
@@ -66,18 +68,18 @@ public class DmfsOpenTasksProvider extends AbstractTaskProvider {
     private String getWhereClause() {
         StringBuilder whereBuilder = new StringBuilder();
 
-        whereBuilder.append(DmfsOpenTasksContract.COLUMN_STATUS).append(NOT_EQUALS).append(DmfsOpenTasksContract.STATUS_COMPLETED);
+        whereBuilder.append(DmfsOpenTasksContract.Tasks.COLUMN_STATUS).append(NOT_EQUALS).append(DmfsOpenTasksContract.Tasks.STATUS_COMPLETED);
 
         // @formatter:off
         whereBuilder.append(AND_BRACKET)
-                .append(DmfsOpenTasksContract.COLUMN_DUE_DATE).append(LTE).append(mEndOfTimeRange.getMillis())
+                .append(DmfsOpenTasksContract.Tasks.COLUMN_DUE_DATE).append(LTE).append(mEndOfTimeRange.getMillis())
                 .append(OR)
                     .append(OPEN_BRACKET)
-                        .append(DmfsOpenTasksContract.COLUMN_DUE_DATE).append(IS_NULL)
+                        .append(DmfsOpenTasksContract.Tasks.COLUMN_DUE_DATE).append(IS_NULL)
                         .append(AND_BRACKET)
-                            .append(DmfsOpenTasksContract.COLUMN_START_DATE).append(LTE).append(mEndOfTimeRange.getMillis())
+                            .append(DmfsOpenTasksContract.Tasks.COLUMN_START_DATE).append(LTE).append(mEndOfTimeRange.getMillis())
                             .append(OR)
-                            .append(DmfsOpenTasksContract.COLUMN_START_DATE).append(IS_NULL)
+                            .append(DmfsOpenTasksContract.Tasks.COLUMN_START_DATE).append(IS_NULL)
                         .append(CLOSING_BRACKET)
                     .append(CLOSING_BRACKET)
                 .append(CLOSING_BRACKET);
@@ -88,20 +90,52 @@ public class DmfsOpenTasksProvider extends AbstractTaskProvider {
 
     private TaskEvent createTask(Cursor cursor) {
         TaskEvent task = new DmfsOpenTasksEvent(zone);
-        task.setId(cursor.getLong(cursor.getColumnIndex(DmfsOpenTasksContract.COLUMN_ID)));
-        task.setTitle(cursor.getString(cursor.getColumnIndex(DmfsOpenTasksContract.COLUMN_TITLE)));
+        task.setId(cursor.getLong(cursor.getColumnIndex(DmfsOpenTasksContract.Tasks.COLUMN_ID)));
+        task.setTitle(cursor.getString(cursor.getColumnIndex(DmfsOpenTasksContract.Tasks.COLUMN_TITLE)));
 
-        int dueDateIdx = cursor.getColumnIndex(DmfsOpenTasksContract.COLUMN_DUE_DATE);
+        int dueDateIdx = cursor.getColumnIndex(DmfsOpenTasksContract.Tasks.COLUMN_DUE_DATE);
         Long dueMillis = null;
         if (!cursor.isNull(dueDateIdx)) {
             dueMillis = cursor.getLong(dueDateIdx);
         }
-        int startDateIdx = cursor.getColumnIndex(DmfsOpenTasksContract.COLUMN_START_DATE);
+        int startDateIdx = cursor.getColumnIndex(DmfsOpenTasksContract.Tasks.COLUMN_START_DATE);
         Long startMillis = null;
         if (!cursor.isNull(startDateIdx)) {
             startMillis = cursor.getLong(startDateIdx);
         }
         task.setDates(startMillis, dueMillis);
         return task;
+    }
+
+    @Override
+    public Collection<EventSource> getTaskLists() {
+        ArrayList<EventSource> eventSources = new ArrayList<>();
+
+        String[] projection = {
+                DmfsOpenTasksContract.TaskLists.COLUMN_ID,
+                DmfsOpenTasksContract.TaskLists.COLUMN_NAME,
+                DmfsOpenTasksContract.TaskLists.COLUMN_COLOR,
+                DmfsOpenTasksContract.TaskLists.COLUMN_ACCOUNT_NAME,
+        };
+        Cursor cursor = context.getContentResolver().query(DmfsOpenTasksContract.TaskLists.PROVIDER_URI, projection, null, null, null);
+        if (cursor == null) {
+            return eventSources;
+        }
+
+        int idIdx = cursor.getColumnIndex(DmfsOpenTasksContract.TaskLists.COLUMN_ID);
+        int nameIdx = cursor.getColumnIndex(DmfsOpenTasksContract.TaskLists.COLUMN_NAME);
+        int colorIdx = cursor.getColumnIndex(DmfsOpenTasksContract.TaskLists.COLUMN_COLOR);
+        int accountIdx = cursor.getColumnIndex(DmfsOpenTasksContract.TaskLists.COLUMN_ACCOUNT_NAME);
+        try {
+            while (cursor.moveToNext()) {
+                EventSource eventSource = new EventSource(cursor.getInt(idIdx), cursor.getString(nameIdx),
+                        cursor.getString(accountIdx), cursor.getInt(colorIdx));
+                eventSources.add(eventSource);
+            }
+        } finally {
+            cursor.close();
+        }
+
+        return eventSources;
     }
 }

--- a/app/src/main/java/org/andstatus/todoagenda/task/dmfs/DmfsOpenTasksProvider.java
+++ b/app/src/main/java/org/andstatus/todoagenda/task/dmfs/DmfsOpenTasksProvider.java
@@ -42,7 +42,12 @@ public class DmfsOpenTasksProvider extends AbstractTaskProvider {
 
         CalendarQueryResult result = new CalendarQueryResult(getSettings(), uri, projection, where, null, null);
 
-        Cursor cursor = context.getContentResolver().query(uri, projection, where, null, null);
+        Cursor cursor;
+        try {
+            cursor = context.getContentResolver().query(uri, projection, where, null, null);
+        } catch (IllegalArgumentException e) {
+            cursor = null;
+        }
         if (cursor == null) {
             return new ArrayList<>();
         }
@@ -132,7 +137,12 @@ public class DmfsOpenTasksProvider extends AbstractTaskProvider {
                 DmfsOpenTasksContract.TaskLists.COLUMN_COLOR,
                 DmfsOpenTasksContract.TaskLists.COLUMN_ACCOUNT_NAME,
         };
-        Cursor cursor = context.getContentResolver().query(DmfsOpenTasksContract.TaskLists.PROVIDER_URI, projection, null, null, null);
+        Cursor cursor;
+        try {
+            cursor = context.getContentResolver().query(DmfsOpenTasksContract.TaskLists.PROVIDER_URI, projection, null, null, null);
+        } catch (IllegalArgumentException e) {
+            cursor = null;
+        }
         if (cursor == null) {
             return eventSources;
         }

--- a/app/src/main/java/org/andstatus/todoagenda/task/dmfs/DmfsOpenTasksProvider.java
+++ b/app/src/main/java/org/andstatus/todoagenda/task/dmfs/DmfsOpenTasksProvider.java
@@ -3,6 +3,7 @@ package org.andstatus.todoagenda.task.dmfs;
 import android.content.Context;
 import android.database.Cursor;
 import android.net.Uri;
+import android.text.TextUtils;
 
 import org.andstatus.todoagenda.calendar.CalendarQueryResult;
 import org.andstatus.todoagenda.calendar.CalendarQueryResultsStorage;
@@ -13,6 +14,7 @@ import org.andstatus.todoagenda.task.TaskEvent;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
+import java.util.Set;
 
 public class DmfsOpenTasksProvider extends AbstractTaskProvider {
 
@@ -84,6 +86,15 @@ public class DmfsOpenTasksProvider extends AbstractTaskProvider {
                     .append(CLOSING_BRACKET)
                 .append(CLOSING_BRACKET);
         // @formatter:on
+
+        Set<String> taskLists = getSettings().getActiveTaskLists();
+        if (!taskLists.isEmpty()) {
+            whereBuilder.append(AND);
+            whereBuilder.append(DmfsOpenTasksContract.Tasks.COLUMN_LIST_ID);
+            whereBuilder.append(" IN ( ");
+            whereBuilder.append(TextUtils.join(",", taskLists));
+            whereBuilder.append(CLOSING_BRACKET);
+        }
 
         return whereBuilder.toString();
     }

--- a/app/src/main/java/org/andstatus/todoagenda/task/dmfs/DmfsOpenTasksProvider.java
+++ b/app/src/main/java/org/andstatus/todoagenda/task/dmfs/DmfsOpenTasksProvider.java
@@ -36,6 +36,7 @@ public class DmfsOpenTasksProvider extends AbstractTaskProvider {
                 DmfsOpenTasksContract.Tasks.COLUMN_TITLE,
                 DmfsOpenTasksContract.Tasks.COLUMN_DUE_DATE,
                 DmfsOpenTasksContract.Tasks.COLUMN_START_DATE,
+                DmfsOpenTasksContract.Tasks.COLUMN_COLOR,
         };
         String where = getWhereClause();
 
@@ -115,6 +116,9 @@ public class DmfsOpenTasksProvider extends AbstractTaskProvider {
             startMillis = cursor.getLong(startDateIdx);
         }
         task.setDates(startMillis, dueMillis);
+
+        task.setColor(getAsOpaque(cursor.getInt(cursor.getColumnIndex(DmfsOpenTasksContract.Tasks.COLUMN_COLOR))));
+
         return task;
     }
 

--- a/app/src/main/java/org/andstatus/todoagenda/task/samsung/SamsungTasksContract.java
+++ b/app/src/main/java/org/andstatus/todoagenda/task/samsung/SamsungTasksContract.java
@@ -4,13 +4,27 @@ import android.net.Uri;
 
 public class SamsungTasksContract {
 
-    public static final Uri PROVIDER_URI = Uri.parse("content://com.android.calendar/syncTasks");
+    public static class Tasks {
 
-    public static final String COLUMN_ID = "_id";
-    public static final String COLUMN_TITLE = "subject";
-    public static final String COLUMN_DUE_DATE = "utc_due_date";
-    public static final String COLUMN_COMPLETE = "complete";
-    public static final String COLUMN_DELETED = "deleted";
+        public static final Uri PROVIDER_URI = Uri.parse("content://com.android.calendar/syncTasks");
+
+        public static final String COLUMN_ID = "_id";
+        public static final String COLUMN_TITLE = "subject";
+        public static final String COLUMN_DUE_DATE = "utc_due_date";
+        public static final String COLUMN_COLOR = "secAccountColor";
+        public static final String COLUMN_COMPLETE = "complete";
+        public static final String COLUMN_DELETED = "deleted";
+        public static final String COLUMN_LIST_ID = "accountKey";
+    }
+
+    public static class TaskLists {
+
+        public static final Uri PROVIDER_URI = Uri.parse("content://com.android.calendar/TasksAccounts");
+
+        public static final String COLUMN_ID = "_sync_account_key";
+        public static final String COLUMN_NAME = "displayName";
+        public static final String COLUMN_COLOR = "secAccountColor";
+    }
 
     public static final String INTENT_EXTRA_TASK = "task";
     public static final String INTENT_EXTRA_SELECTED = "selected";

--- a/app/src/main/java/org/andstatus/todoagenda/task/samsung/SamsungTasksProvider.java
+++ b/app/src/main/java/org/andstatus/todoagenda/task/samsung/SamsungTasksProvider.java
@@ -42,7 +42,12 @@ public class SamsungTasksProvider extends AbstractTaskProvider {
 
         CalendarQueryResult result = new CalendarQueryResult(getSettings(), uri, projection, where, null, null);
 
-        Cursor cursor = context.getContentResolver().query(uri, projection, where, null, null);
+        Cursor cursor;
+        try {
+            cursor = context.getContentResolver().query(uri, projection, where, null, null);
+        } catch (IllegalArgumentException e) {
+            cursor = null;
+        }
         if (cursor == null) {
             return new ArrayList<>();
         }
@@ -118,7 +123,12 @@ public class SamsungTasksProvider extends AbstractTaskProvider {
                 SamsungTasksContract.TaskLists.COLUMN_NAME,
                 SamsungTasksContract.TaskLists.COLUMN_COLOR,
         };
-        Cursor cursor = context.getContentResolver().query(SamsungTasksContract.TaskLists.PROVIDER_URI, projection, null, null, null);
+        Cursor cursor;
+        try {
+            cursor = context.getContentResolver().query(SamsungTasksContract.TaskLists.PROVIDER_URI, projection, null, null, null);
+        } catch (IllegalArgumentException e) {
+            cursor = null;
+        }
         if (cursor == null) {
             return eventSources;
         }

--- a/app/src/main/java/org/andstatus/todoagenda/task/samsung/SamsungTasksProvider.java
+++ b/app/src/main/java/org/andstatus/todoagenda/task/samsung/SamsungTasksProvider.java
@@ -3,7 +3,9 @@ package org.andstatus.todoagenda.task.samsung;
 import android.content.Context;
 import android.database.Cursor;
 import android.net.Uri;
+import android.text.TextUtils;
 
+import org.andstatus.todoagenda.R;
 import org.andstatus.todoagenda.calendar.CalendarQueryResult;
 import org.andstatus.todoagenda.calendar.CalendarQueryResultsStorage;
 import org.andstatus.todoagenda.prefs.EventSource;
@@ -13,6 +15,7 @@ import org.andstatus.todoagenda.task.TaskEvent;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
+import java.util.Set;
 
 public class SamsungTasksProvider extends AbstractTaskProvider {
 
@@ -27,11 +30,13 @@ public class SamsungTasksProvider extends AbstractTaskProvider {
     }
 
     private List<TaskEvent> queryTasks() {
-        Uri uri = SamsungTasksContract.PROVIDER_URI;
+        Uri uri = SamsungTasksContract.Tasks.PROVIDER_URI;
         String[] projection = {
-                SamsungTasksContract.COLUMN_ID,
-                SamsungTasksContract.COLUMN_TITLE,
-                SamsungTasksContract.COLUMN_DUE_DATE
+                SamsungTasksContract.Tasks.COLUMN_ID,
+                SamsungTasksContract.Tasks.COLUMN_TITLE,
+                SamsungTasksContract.Tasks.COLUMN_DUE_DATE,
+                SamsungTasksContract.Tasks.COLUMN_COLOR,
+                SamsungTasksContract.Tasks.COLUMN_LIST_ID,
         };
         String where = getWhereClause();
 
@@ -65,34 +70,84 @@ public class SamsungTasksProvider extends AbstractTaskProvider {
 
     private String getWhereClause() {
         StringBuilder whereBuilder = new StringBuilder();
-        whereBuilder.append(SamsungTasksContract.COLUMN_COMPLETE).append(EQUALS).append("0");
-        whereBuilder.append(AND).append(SamsungTasksContract.COLUMN_DELETED).append(EQUALS).append("0");
+        whereBuilder.append(SamsungTasksContract.Tasks.COLUMN_COMPLETE).append(EQUALS).append("0");
+        whereBuilder.append(AND).append(SamsungTasksContract.Tasks.COLUMN_DELETED).append(EQUALS).append("0");
 
         whereBuilder.append(AND_BRACKET)
-                .append(SamsungTasksContract.COLUMN_DUE_DATE).append(LTE).append(mEndOfTimeRange.getMillis())
+                .append(SamsungTasksContract.Tasks.COLUMN_DUE_DATE).append(LTE).append(mEndOfTimeRange.getMillis())
                 .append(OR)
-                .append(SamsungTasksContract.COLUMN_DUE_DATE).append(IS_NULL)
+                .append(SamsungTasksContract.Tasks.COLUMN_DUE_DATE).append(IS_NULL)
                 .append(CLOSING_BRACKET);
+
+        Set<String> taskLists = getSettings().getActiveTaskLists();
+        if (!taskLists.isEmpty()) {
+            whereBuilder.append(AND);
+            whereBuilder.append(SamsungTasksContract.Tasks.COLUMN_LIST_ID);
+            whereBuilder.append(" IN ( ");
+            whereBuilder.append(TextUtils.join(",", taskLists));
+            whereBuilder.append(CLOSING_BRACKET);
+        }
 
         return whereBuilder.toString();
     }
 
     private TaskEvent createTask(Cursor cursor) {
         TaskEvent task = new SamsungTaskEvent(zone);
-        task.setId(cursor.getLong(cursor.getColumnIndex(SamsungTasksContract.COLUMN_ID)));
-        task.setTitle(cursor.getString(cursor.getColumnIndex(SamsungTasksContract.COLUMN_TITLE)));
+        task.setId(cursor.getLong(cursor.getColumnIndex(SamsungTasksContract.Tasks.COLUMN_ID)));
+        task.setTitle(cursor.getString(cursor.getColumnIndex(SamsungTasksContract.Tasks.COLUMN_TITLE)));
 
-        int dueDateIdx = cursor.getColumnIndex(SamsungTasksContract.COLUMN_DUE_DATE);
+        int dueDateIdx = cursor.getColumnIndex(SamsungTasksContract.Tasks.COLUMN_DUE_DATE);
         Long dueMillis = null;
         if (!cursor.isNull(dueDateIdx)) {
             dueMillis = cursor.getLong(dueDateIdx);
         }
         task.setDates(null, dueMillis);
+
+        task.setColor(getColor(cursor, cursor.getColumnIndex(SamsungTasksContract.Tasks.COLUMN_COLOR),
+                cursor.getInt(cursor.getColumnIndex(SamsungTasksContract.Tasks.COLUMN_LIST_ID))));
+
         return task;
     }
 
     @Override
     public Collection<EventSource> getTaskLists() {
-        return new ArrayList<>();
+        ArrayList<EventSource> eventSources = new ArrayList<>();
+
+        String[] projection = {
+                SamsungTasksContract.TaskLists.COLUMN_ID,
+                SamsungTasksContract.TaskLists.COLUMN_NAME,
+                SamsungTasksContract.TaskLists.COLUMN_COLOR,
+        };
+        Cursor cursor = context.getContentResolver().query(SamsungTasksContract.TaskLists.PROVIDER_URI, projection, null, null, null);
+        if (cursor == null) {
+            return eventSources;
+        }
+
+        String taskListName = context.getResources().getString(R.string.task_prefs);
+        int idIdx = cursor.getColumnIndex(SamsungTasksContract.TaskLists.COLUMN_ID);
+        int nameIdx = cursor.getColumnIndex(SamsungTasksContract.TaskLists.COLUMN_NAME);
+        int colorIdx = cursor.getColumnIndex(SamsungTasksContract.TaskLists.COLUMN_COLOR);
+        try {
+            while (cursor.moveToNext()) {
+                int id = cursor.getInt(idIdx);
+                EventSource eventSource = new EventSource(id, taskListName,
+                        cursor.getString(nameIdx), getColor(cursor, colorIdx, id));
+                eventSources.add(eventSource);
+            }
+        } finally {
+            cursor.close();
+        }
+
+        return eventSources;
+    }
+
+    private int getColor(Cursor cursor, int colorIdx, int accountId) {
+        if (!cursor.isNull(colorIdx)) {
+            return getAsOpaque(cursor.getInt(colorIdx));
+        } else {
+            int[] fixedColors = context.getResources().getIntArray(R.array.task_list_colors);
+            int arrayIdx = accountId % fixedColors.length;
+            return fixedColors[arrayIdx];
+        }
     }
 }

--- a/app/src/main/java/org/andstatus/todoagenda/task/samsung/SamsungTasksProvider.java
+++ b/app/src/main/java/org/andstatus/todoagenda/task/samsung/SamsungTasksProvider.java
@@ -6,10 +6,12 @@ import android.net.Uri;
 
 import org.andstatus.todoagenda.calendar.CalendarQueryResult;
 import org.andstatus.todoagenda.calendar.CalendarQueryResultsStorage;
+import org.andstatus.todoagenda.prefs.EventSource;
 import org.andstatus.todoagenda.task.AbstractTaskProvider;
 import org.andstatus.todoagenda.task.TaskEvent;
 
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.List;
 
 public class SamsungTasksProvider extends AbstractTaskProvider {
@@ -87,5 +89,10 @@ public class SamsungTasksProvider extends AbstractTaskProvider {
         }
         task.setDates(null, dueMillis);
         return task;
+    }
+
+    @Override
+    public Collection<EventSource> getTaskLists() {
+        return new ArrayList<>();
     }
 }

--- a/app/src/main/res/values/arrays.xml
+++ b/app/src/main/res/values/arrays.xml
@@ -103,4 +103,16 @@
         <item>DMFS_OPEN_TASKS</item>
         <item>SAMSUNG</item>
     </string-array>
+    <integer-array name="task_list_colors">
+        <item>@color/task_list_0</item>
+        <item>@color/task_list_1</item>
+        <item>@color/task_list_2</item>
+        <item>@color/task_list_3</item>
+        <item>@color/task_list_4</item>
+        <item>@color/task_list_5</item>
+        <item>@color/task_list_6</item>
+        <item>@color/task_list_7</item>
+        <item>@color/task_list_8</item>
+        <item>@color/task_list_9</item>
+    </integer-array>
 </resources>

--- a/app/src/main/res/values/colors.xml
+++ b/app/src/main/res/values/colors.xml
@@ -34,4 +34,16 @@
     <color name="colorPrimaryDark">#37474f</color>
     <color name="colorAccent">#009688</color>
 
+    <!-- Task list colors for providers that don't supply this information -->
+    <color name="task_list_0">#2196f3</color>
+    <color name="task_list_1">#009688</color>
+    <color name="task_list_2">#607d8d</color>
+    <color name="task_list_3">#795548</color>
+    <color name="task_list_4">#ffc107</color>
+    <color name="task_list_5">#f44336</color>
+    <color name="task_list_6">#00bcd4</color>
+    <color name="task_list_7">#cddc39</color>
+    <color name="task_list_8">#9c27b0</color>
+    <color name="task_list_9">#4caf59</color>
+
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -145,6 +145,8 @@
     <string name="task_source_none">Don\'t display tasks</string>
     <string name="task_source_opentasks">OpenTasks (by dmfs GmbH)</string>
     <string name="task_source_samsung">Samsung Calendar</string>
+    <string name="task_lists_pref_title">Task lists</string>
+    <string name="task_lists_pref_summary">Select the task lists to display</string>
 
     <!-- Preference header: Feedback -->
     <string name="feedback_prefs">Feedback</string>

--- a/app/src/main/res/xml/preferences_task.xml
+++ b/app/src/main/res/xml/preferences_task.xml
@@ -6,4 +6,11 @@
         android:key="taskSource"
         android:title="@string/task_source_pref_title"
         android:summary="@string/task_source_pref_desc" />
+
+    <Preference
+        android:fragment="org.andstatus.todoagenda.prefs.TaskListsPreferencesFragment"
+        android:key="activeTaskListsButton"
+        android:persistent="false"
+        android:title="@string/task_lists_pref_title"
+        android:summary="@string/task_lists_pref_summary" />
 </PreferenceScreen>


### PR DESCRIPTION
This should be the last big change: support for selecting which task lists to display. I've reused essentially the calendar selection logic already existing.

Works great for OpenTasks, but needed a few workarounds for Samsung (it does not support all features necessary), as described in its commit.

This should be independent of the discussion we're having about task dates in #308; whatever is decided should not require changes here.

---

Fun fact: while on the emulator setting the color of the check mark works fine, in my Samsung S9 (Android 9), they're always dark gray. A font issue, perhaps? Any suggestions on another symbol for tasks? Leave as is?